### PR TITLE
Added support for some pthread functions

### DIFF
--- a/Lib/Emscripten/Emscripten.cpp
+++ b/Lib/Emscripten/Emscripten.cpp
@@ -50,6 +50,11 @@ enum
 	minStaticEmscriptenMemoryPages = 128
 };
 
+enum ErrNo
+{
+	einval = 22
+};
+
 struct MutableGlobals
 {
 	enum
@@ -174,8 +179,7 @@ static int pthreadSpecificNextKey = 0;
 DEFINE_INTRINSIC_FUNCTION_WITH_MEM_AND_TABLE(env, "_pthread_key_create", I32, _pthread_key_create, I32 key, I32 destructorPtr)
 {
 	if (key == 0) {
-		// ErrNo codes - einval
-		return 22;
+		return ErrNo::einval;
 	}
 
 	MemoryInstance* memory
@@ -194,8 +198,7 @@ DEFINE_INTRINSIC_FUNCTION(env, "_pthread_mutex_unlock", I32, _pthread_mutex_unlo
 DEFINE_INTRINSIC_FUNCTION(env, "_pthread_setspecific", I32, _pthread_setspecific, I32 key, I32 value)
 {
 	if (!pthreadSpecific.contains(key)) {
-		// ErrNo codes - einval
-		return 22;
+		return ErrNo::einval;
     }
 	pthreadSpecific.set(key, value);
 	return 0;

--- a/Lib/Emscripten/Emscripten.cpp
+++ b/Lib/Emscripten/Emscripten.cpp
@@ -180,7 +180,7 @@ DEFINE_INTRINSIC_FUNCTION_WITH_MEM_AND_TABLE(env, "_pthread_key_create", I32, _p
 
 	MemoryInstance* memory
 		= Runtime::getMemoryFromRuntimeData(contextRuntimeData, defaultMemoryId.id);
-	memoryRef<U32>(memory, key >> 2) = pthreadSpecificNextKey;
+	memoryRef<U32>(memory, key) = pthreadSpecificNextKey;
 	pthreadSpecific.set(pthreadSpecificNextKey, 0);
 	pthreadSpecificNextKey++;
 

--- a/Lib/Emscripten/Emscripten.cpp
+++ b/Lib/Emscripten/Emscripten.cpp
@@ -205,11 +205,7 @@ DEFINE_INTRINSIC_FUNCTION(env, "_pthread_setspecific", I32, _pthread_setspecific
 }
 DEFINE_INTRINSIC_FUNCTION(env, "_pthread_getspecific", I32, _pthread_getspecific, I32 key)
 {
-	const I32 *value = pthreadSpecific.get(key);
-	if (value == NULL) {
-		return 0;
-	}
-	return *value;
+	return (I32)*pthreadSpecific.get(key);
 }
 DEFINE_INTRINSIC_FUNCTION(env, "_pthread_once", I32, _pthread_once, I32 a, I32 b)
 {


### PR DESCRIPTION
First, thanks a lot for your project. It represents an incredible leap forward into executing wasm universal binaries into a broad set of architectures.

I've been playing with it a bit, trying to port some functions from emscripten, like the following related to pthreads:

```js
    function _pthread_setspecific(key, value) {
        if (!(key in PTHREAD_SPECIFIC)) {
            return ERRNO_CODES.EINVAL
        }
        PTHREAD_SPECIFIC[key] = value;
        return 0
    }
    Module["_pthread_setspecific"] = _pthread_setspecific;


    function _pthread_key_create(key, destructor) {
        if (key == 0) {
            return ERRNO_CODES.EINVAL
        }
        HEAP32[key >> 2] = PTHREAD_SPECIFIC_NEXT_KEY;
        PTHREAD_SPECIFIC[PTHREAD_SPECIFIC_NEXT_KEY] = 0;
        PTHREAD_SPECIFIC_NEXT_KEY++;
        return 0
    }
    Module["_pthread_key_create"] = _pthread_key_create;

    function _pthread_getspecific(key) {
        return PTHREAD_SPECIFIC[key] || 0
    }
    Module["_pthread_getspecific"] = _pthread_getspecific;
```

PS: I have not much experience with C, or porting JS functions to it.

I will love to get reviewed and keep collaborating into such a great project.