### PR TITLE
Add _emscripten_get_heap_size and _emscripten_resize_heap functions.

### DIFF
--- a/Lib/Emscripten/Emscripten.cpp
+++ b/Lib/Emscripten/Emscripten.cpp
@@ -144,6 +144,10 @@ DEFINE_INTRINSIC_FUNCTION(env, "getTotalMemory", U32, getTotalMemory)
 	return coerce32bitAddress(emscriptenMemory,
 							  Runtime::getMemoryMaxPages(emscriptenMemory) * IR::numBytesPerPage);
 }
+DEFINE_INTRINSIC_FUNCTION(env, "_emscripten_get_heap_size", U32, _emscripten_get_heap_size)
+{
+	return getTotalMemory(contextRuntimeData);
+}
 
 DEFINE_INTRINSIC_FUNCTION(env, "abortStackOverflow", void, abortStackOverflow, I32 size)
 {
@@ -157,6 +161,10 @@ DEFINE_INTRINSIC_FUNCTION(env, "abortOnCannotGrowMemory", I32, abortOnCannotGrow
 DEFINE_INTRINSIC_FUNCTION(env, "enlargeMemory", I32, enlargeMemory)
 {
 	return abortOnCannotGrowMemory(contextRuntimeData);
+}
+DEFINE_INTRINSIC_FUNCTION(env, "_emscripten_resize_heap", I32, _emscripten_resize_heap, U32 size)
+{
+	return enlargeMemory(contextRuntimeData);
 }
 
 DEFINE_INTRINSIC_FUNCTION(env, "_time", I32, _time, U32 address)


### PR DESCRIPTION
This matches changes in Emscripten v1.38.25.

Leaving getTotalMemory and enlargeMemory for backward compatibility.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>