### PR TITLE
Update metrics log info from kilo-byte to kibi-byte

### DIFF
--- a/Lib/WASTParse/ParseModule.cpp
+++ b/Lib/WASTParse/ParseModule.cpp
@@ -1065,7 +1065,7 @@ template<typename Map> void dumpHashMapSpaceAnalysis(const Map& map, const char*
 		map.analyzeSpaceUsage(totalMemoryBytes, maxProbeCount, occupancy, averageProbeCount);
 		Log::printf(
 			Log::metrics,
-			"%s used %.1fKB for %" PRIuPTR
+			"%s used %.1fKiB for %" PRIuPTR
 			" elements (%.0f%% occupancy, %.1f bytes/element). Avg/max probe length: %f/%" PRIuPTR
 			"\n",
 			description,

--- a/Programs/wavm-run-wasi/wavm-run-wasi.cpp
+++ b/Programs/wavm-run-wasi/wavm-run-wasi.cpp
@@ -245,7 +245,7 @@ int main(int argc, char** argv)
 
 	// Log the peak memory usage.
 	Uptr peakMemoryUsage = Platform::getPeakMemoryUsageBytes();
-	Log::printf(Log::metrics, "Peak memory usage: %" PRIuPTR "KB\n", peakMemoryUsage / 1024);
+	Log::printf(Log::metrics, "Peak memory usage: %" PRIuPTR "KiB\n", peakMemoryUsage / 1024);
 
 	return result;
 }

--- a/Programs/wavm-run/wavm-run.cpp
+++ b/Programs/wavm-run/wavm-run.cpp
@@ -385,7 +385,7 @@ int main(int argc, char** argv)
 
 	// Log the peak memory usage.
 	Uptr peakMemoryUsage = Platform::getPeakMemoryUsageBytes();
-	Log::printf(Log::metrics, "Peak memory usage: %" PRIuPTR "KB\n", peakMemoryUsage / 1024);
+	Log::printf(Log::metrics, "Peak memory usage: %" PRIuPTR "KiB\n", peakMemoryUsage / 1024);
 
 	return result;
 }


### PR DESCRIPTION
Since the calculation of the metric uses 1024 as a base, the resulting unit is technically kibibytes(KiB), instead of kilobytes(KB).

This change breaks code, that parses the log of wavm-run and is looking for "KB" to find the metric