### PR TITLE
Fix compile error under gcc8

### DIFF
--- a/Lib/wavm-c/wavm-c.cpp
+++ b/Lib/wavm-c/wavm-c.cpp
@@ -790,7 +790,7 @@ wasm_trap_t* wasm_func_call(wasm_store_t* store,
 	FunctionType functionType = getFunctionType((Function*)function);
 	auto wavmArgs = (UntaggedValue*)alloca(functionType.params().size() * sizeof(UntaggedValue));
 	for(Uptr argIndex = 0; argIndex < functionType.params().size(); ++argIndex)
-	{ memcpy(&wavmArgs[argIndex], &args[argIndex], sizeof(wasm_val_t)); }
+	{ memcpy(&wavmArgs[argIndex].bytes, &args[argIndex], sizeof(wasm_val_t)); }
 
 	try
 	{


### PR DESCRIPTION
Gcc version:
`gcc (GCC) 8.3.1`

Compile error:  
```
/home/shangxu.cjy/code/wavm/WAVM/Lib/wavm-c/wavm-c.cpp: In function ‘wasm_trap_t* wasm_func_call(wasm_store_t*, const wasm_func_t*, const wasm_val_t*, wasm_val_t*)’:
/home/shangxu.cjy/code/wavm/WAVM/Lib/wavm-c/wavm-c.cpp:793:67: error: ‘void* memcpy(void*, const void*, size_t)’ copying an object of non-trivial type ‘struct WAVM::IR::UntaggedValue’ from an array of ‘const wasm_val_t’ {aka ‘const union wasm_val_t’} [-Werror=class-memaccess]
  { memcpy(&wavmArgs[argIndex], &args[argIndex], sizeof(wasm_val_t)); }
                                                                   ^
In file included from /home/shangxu.cjy/code/wavm/WAVM/Include/WAVM/Runtime/RuntimeData.h:11,
                 from /home/shangxu.cjy/code/wavm/WAVM/Include/WAVM/LLVMJIT/LLVMJIT.h:10,
                 from /home/shangxu.cjy/code/wavm/WAVM/Lib/wavm-c/wavm-c.cpp:7:
/home/shangxu.cjy/code/wavm/WAVM/Include/WAVM/IR/Value.h:14:9: note: ‘struct WAVM::IR::UntaggedValue’ declared here
  struct UntaggedValue
         ^~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [CMakeFiles/WAVM.dir/Lib/wavm-c/wavm-c.cpp.o] Error 1
make[1]: *** [CMakeFiles/WAVM.dir/all] Error 2
make: *** [all] Error 2
```
