### PR TITLE
wavm-c: added wasm_func_name() to be able to interpret trap stack frames

### DIFF
--- a/Include/WAVM/wavm-c/wavm-c.h
+++ b/Include/WAVM/wavm-c/wavm-c.h
@@ -441,6 +441,9 @@ WASM_C_API own wasm_func_t* wasm_func_new_with_env(wasm_compartment_t*,
 WASM_C_API own wasm_functype_t* wasm_func_type(const wasm_func_t*);
 WASM_C_API size_t wasm_func_param_arity(const wasm_func_t*);
 WASM_C_API size_t wasm_func_result_arity(const wasm_func_t*);
+WASM_C_API bool wasm_func_name(const wasm_func_t* function,
+							   char* out_message,
+							   size_t* inout_num_message_bytes);
 
 WASM_C_API own wasm_trap_t* wasm_func_call(wasm_store_t*,
 										   const wasm_func_t*,

--- a/Lib/wavm-c/wavm-c.cpp
+++ b/Lib/wavm-c/wavm-c.cpp
@@ -876,6 +876,26 @@ size_t wasm_func_result_arity(const wasm_func_t* function)
 {
 	return getFunctionType(function).results().size();
 }
+bool wasm_func_name(const wasm_func_t* function, char* out_message, size_t* inout_num_message_bytes)
+{
+	if (!function || !function->mutableData) {
+		return false;
+	}
+
+	const auto name = function->mutableData->debugName;
+	if(*inout_num_message_bytes < name.size() + 1)
+	{
+		*inout_num_message_bytes = name.size() + 1;
+		return false;
+	}
+	else
+	{
+		WAVM_ASSERT(out_message);
+		memcpy(out_message, name.c_str(), name.size() + 1);
+		*inout_num_message_bytes = name.size() + 1;
+		return true;
+	}
+}
 
 wasm_trap_t* wasm_func_call(wasm_store_t* store,
 							const wasm_func_t* function,


### PR DESCRIPTION
I'm not sure if this belongs in the C API, but there's no good way of interpreting stack frames without it.