### PR TITLE
[simd] Test ops with missing arguments

### DIFF
--- a/Test/spec/simd/meta/simd_arithmetic.py
+++ b/Test/spec/simd/meta/simd_arithmetic.py
@@ -14,7 +14,7 @@ these arithmetic and saturate arithmetic operations.
 """
 
 from simd import SIMD
-from test_assert import AssertReturn
+from test_assert import AssertReturn, AssertInvalid
 
 
 class LaneNumber:
@@ -325,7 +325,40 @@ class SimdArithmeticCase:
                                                         operand_1='i32.const 0',
                                                         operand_2='f32.const 0.0'))
 
-        return '\n'.join(invalid_cases)
+        return '\n'.join(invalid_cases) + self.argument_empty_test()
+
+    def argument_empty_test(self):
+        """Argument empty cases.
+        """
+        cases = []
+
+        cases.append('\n\n;; Argument empty\n')
+
+        case_data = {
+            'op': '',
+            'extended_name': 'arg-empty',
+            'param_type': '',
+            'result_type': '(result v128)',
+            'params': '',
+        }
+
+        for op in self.UNARY_OPS:
+            case_data['op'] = '{lane_type}.{op}'.format(lane_type=self.LANE_TYPE, op=op)
+            case_data['extended_name'] = 'arg-empty'
+            case_data['params'] = ''
+            cases.append(AssertInvalid.get_arg_empty_test(**case_data))
+
+        for op in self.BINARY_OPS:
+            case_data['op'] = '{lane_type}.{op}'.format(lane_type=self.LANE_TYPE, op=op)
+            case_data['extended_name'] = '1st-arg-empty'
+            case_data['params'] = SIMD.v128_const('0', self.LANE_TYPE)
+            cases.append(AssertInvalid.get_arg_empty_test(**case_data))
+
+            case_data['extended_name'] = 'arg-empty'
+            case_data['params'] = ''
+            cases.append(AssertInvalid.get_arg_empty_test(**case_data))
+
+        return '\n'.join(cases)
 
     def get_combine_cases(self):
         combine_cases = [';; combination\n(module']

--- a/Test/spec/simd/meta/simd_bitwise.py
+++ b/Test/spec/simd/meta/simd_bitwise.py
@@ -5,13 +5,17 @@ This file is used for generating bitwise test cases
 """
 
 from simd import SIMD
-from test_assert import AssertReturn
+from test_assert import AssertReturn, AssertInvalid
 
 
 class SimdBitWise(SIMD):
     """
     Generate common tests
     """
+
+    UNARY_OPS = ('not',)
+    BINARY_OPS = ('and', 'or', 'xor', 'andnot',)
+    TERNARY_OPS = ('bitselect',)
 
     # Test case template
     CASE_TXT = """;; Test all the bitwise operators on major boundary values and all special values.
@@ -182,6 +186,7 @@ class SimdBitWise(SIMD):
         lst_nested_case_func = []
         lst_in_block_case_assert = []
         lst_nested_case_assert = []
+        lst_argument_empty_case = []
 
         for ipr in lst_ipr:
 
@@ -242,9 +247,59 @@ class SimdBitWise(SIMD):
                '{assert_in_block_cases}' \
                '{assert_of_nested_cases}' \
                '\n(assert_return (invoke "as-param"))\n'.format(in_block_cases=''.join(lst_in_block_case_func),
-                                                                nested_cases=''.join(lst_nested_case_func),
-                                                                assert_in_block_cases=''.join(lst_in_block_case_assert),
-                                                                assert_of_nested_cases=''.join(lst_nested_case_assert))
+                                                    nested_cases=''.join(lst_nested_case_func),
+                                                    assert_in_block_cases=''.join(lst_in_block_case_assert),
+                                                    assert_of_nested_cases=''.join(lst_nested_case_assert))
+
+    def get_argument_empty_case(self):
+        """
+        Generate argument empty cases
+        """
+
+        cases = []
+
+        param_1 = SIMD.v128_const('0', 'i32x4')
+
+        cases.append('\n\n;; Argument empty\n')
+
+        case_data = {
+            'op': '',
+            'extended_name': 'arg-empty',
+            'param_type': '',
+            'result_type': '(result v128)',
+            'params': '',
+        }
+
+        for op in self.UNARY_OPS:
+            case_data['op'] = 'v128.' + op
+            cases.append(AssertInvalid.get_arg_empty_test(**case_data))
+
+        for op in self.BINARY_OPS:
+            case_data['op'] = 'v128.' + op
+            case_data['extended_name'] = '1st-arg-empty'
+            case_data['params'] = param_1
+            cases.append(AssertInvalid.get_arg_empty_test(**case_data))
+
+            case_data['extended_name'] = 'arg-empty'
+            case_data['params'] = ''
+            cases.append(AssertInvalid.get_arg_empty_test(**case_data))
+
+        for op in self.TERNARY_OPS:
+            case_data['op'] = 'v128.' + op
+            case_data['extended_name'] = '1st-arg-empty'
+            case_data['params'] = param_1 + ' ' + param_1
+            cases.append(AssertInvalid.get_arg_empty_test(**case_data))
+
+            case_data['extended_name'] = 'two-args-empty'
+            case_data['params'] = param_1
+            cases.append(AssertInvalid.get_arg_empty_test(**case_data))
+
+            case_data['extended_name'] = 'arg-empty'
+            case_data['params'] = ''
+            cases.append(AssertInvalid.get_arg_empty_test(**case_data))
+
+        return '\n'.join(cases) + '\n'
+
 
     def get_all_cases(self):
         """
@@ -254,7 +309,7 @@ class SimdBitWise(SIMD):
         case_data = {'normal_case': self.get_normal_case()}
 
         # Add tests for unkonow operators for i32x4
-        return self.CASE_TXT.format(**case_data) + self.get_invalid_case() + self.get_combination_case()
+        return self.CASE_TXT.format(**case_data) + self.get_invalid_case() + self.get_combination_case() + self.get_argument_empty_case()
 
     def get_case_data(self):
         """

--- a/Test/spec/simd/meta/simd_compare.py
+++ b/Test/spec/simd/meta/simd_compare.py
@@ -9,7 +9,7 @@ via using variable test data set and subclass from sub test template
 
 import abc
 from simd import SIMD
-from test_assert import AssertReturn
+from test_assert import AssertReturn, AssertInvalid
 
 
 # Generate common comparison tests
@@ -369,6 +369,33 @@ class SimdCmpCase(object):
 
         return '\n'.join(cases)
 
+    def argument_empty_test(self):
+        """Argument empty cases.
+        """
+        cases = []
+
+        cases.append('\n;; Argument empty\n')
+
+        case_data = {
+            'op': '',
+            'extended_name': 'arg-empty',
+            'param_type': '',
+            'result_type': '(result v128)',
+            'params': '',
+        }
+
+        for op in self.BINARY_OPS:
+            case_data['op'] = '{lane_type}.{op}'.format(lane_type=self.LANE_TYPE, op=op)
+            case_data['extended_name'] = '1st-arg-empty'
+            case_data['params'] = SIMD.v128_const('0', self.LANE_TYPE)
+            cases.append(AssertInvalid.get_arg_empty_test(**case_data))
+
+            case_data['extended_name'] = 'arg-empty'
+            case_data['params'] = ''
+            cases.append(AssertInvalid.get_arg_empty_test(**case_data))
+
+        return '\n'.join(cases)
+
     # Generate all test cases
     def get_all_cases(self):
 
@@ -376,7 +403,7 @@ class SimdCmpCase(object):
                      'lane_type': self.LANE_TYPE}
 
         # Generate tests using the test template
-        return self.CASE_TXT.format(**case_data)
+        return self.CASE_TXT.format(**case_data) + self.argument_empty_test()
 
     # Generate test case file
     def gen_test_cases(self):

--- a/Test/spec/simd/meta/simd_f32x4_cmp.py
+++ b/Test/spec/simd/meta/simd_f32x4_cmp.py
@@ -16,6 +16,9 @@ from simd_compare import SimdCmpCase
 class Simdf32x4CmpCase(SimdCmpCase):
 
     LANE_TYPE = 'f32x4'
+
+    BINARY_OPS = ['eq', 'ne', 'lt', 'le', 'gt', 'ge']
+
     # Test template, using this template to generate tests with variable test datas.
     CASE_TXT = """;; Test all the {lane_type} comparison operators on major boundary values and all special values.
 

--- a/Test/spec/simd/meta/simd_i16x8_cmp.py
+++ b/Test/spec/simd/meta/simd_i16x8_cmp.py
@@ -14,6 +14,8 @@ class Simdi16x8CmpCase(SimdCmpCase):
 
     LANE_TYPE = 'i16x8'
 
+    BINARY_OPS = ['eq', 'ne', 'lt_s', 'lt_u', 'le_s', 'le_u', 'gt_s', 'gt_u', 'ge_s', 'ge_u']
+
     # Overloads base class method and sets test data for i16x8.
     def get_case_data(self):
 

--- a/Test/spec/simd/meta/simd_i32x4_cmp.py
+++ b/Test/spec/simd/meta/simd_i32x4_cmp.py
@@ -14,6 +14,8 @@ class Simdi32x4CmpCase(SimdCmpCase):
 
     LANE_TYPE = 'i32x4'
 
+    BINARY_OPS = ['eq', 'ne', 'lt_s', 'lt_u', 'le_s', 'le_u', 'gt_s', 'gt_u', 'ge_s', 'ge_u']
+
     # Overload base class method and set test data for i32x4.
     def get_case_data(self):
 

--- a/Test/spec/simd/meta/simd_i8x16_cmp.py
+++ b/Test/spec/simd/meta/simd_i8x16_cmp.py
@@ -15,6 +15,8 @@ class Simdi8x16CmpCase(SimdCmpCase):
     # set lane type
     LANE_TYPE = 'i8x16'
 
+    BINARY_OPS = ['eq', 'ne', 'lt_s', 'lt_u', 'le_s', 'le_u', 'gt_s', 'gt_u', 'ge_s', 'ge_u']
+
     # Overload base class method and set test data for i32x4.
     def get_case_data(self):
 

--- a/Test/spec/simd/meta/simd_int_arith2.py
+++ b/Test/spec/simd/meta/simd_int_arith2.py
@@ -5,7 +5,7 @@ Generate [min_s, min_u, max_s, max_u] cases for i32x4, i16x8 and i8x16.
 """
 
 from simd import SIMD
-from test_assert import AssertReturn
+from test_assert import AssertReturn, AssertInvalid
 from simd_lane_value import LaneValue
 from simd_integer_op import IntegerSimpleOp as IntOp
 
@@ -319,31 +319,29 @@ class SimdLaneWiseInteger:
     def gen_test_case_empty_argument(self):
         """generate empty argument test cases"""
 
-        assert_1st_empyt_template = '\n(assert_invalid' \
-                                    '\n  (module' \
-                                    '\n    (func ${lane_type}.{op}-1st-arg-empty (result v128)' \
-                                    '\n      ({lane_type}.{op} {param_1})' \
-                                    '\n    )' \
-                                    '\n  )' \
-                                    '\n  "type mismatch"' \
-                                    '\n)'
-        assert_all_empty_template = '\n(assert_invalid' \
-                                    '\n  (module' \
-                                    '\n    (func ${lane_type}.{op}-all-args-empty (result v128)' \
-                                    '\n      ({lane_type}.{op})' \
-                                    '\n    )' \
-                                    '\n  )' \
-                                    '\n  "type mismatch"' \
-                                    '\n)'
+        cases = []
 
-        cases = ''
+        cases.append('\n\n;; Argument empty\n')
 
-        cases += '\n\n;; Test operation with empty argument\n'
+        case_data = {
+            'op': '',
+            'extended_name': 'arg-empty',
+            'param_type': '',
+            'result_type': '(result v128)',
+            'params': '',
+        }
+
         for op in self.BINARY_OPS:
-            cases += assert_1st_empyt_template.format(lane_type=self.LANE_TYPE, op=op, param_1=SIMD.v128_const('0', self.LANE_TYPE))
-            cases += assert_all_empty_template.format(lane_type=self.LANE_TYPE, op=op)
+            case_data['op'] = '{lane_type}.{op}'.format(lane_type=self.LANE_TYPE, op=op)
+            case_data['extended_name'] = '1st-arg-empty'
+            case_data['params'] = SIMD.v128_const('0', self.LANE_TYPE)
+            cases.append(AssertInvalid.get_arg_empty_test(**case_data))
 
-        return cases
+            case_data['extended_name'] = 'arg-empty'
+            case_data['params'] = ''
+            cases.append(AssertInvalid.get_arg_empty_test(**case_data))
+
+        return '\n'.join(cases)
 
     @property
     def gen_funcs(self):

--- a/Test/spec/simd/meta/simd_sat_arith.py
+++ b/Test/spec/simd/meta/simd_sat_arith.py
@@ -42,6 +42,31 @@ class SimdSaturateArithmeticCases(SimdArithmeticCase):
 
         return '\n'.join(malformed_cases)
 
+    def argument_empty_cases(self):
+        """Argument empty cases.
+        """
+        cases = []
+
+        case_data = {
+            'op': '',
+            'extended_name': 'arg-empty',
+            'param_type': '',
+            'result_type': '(result v128)',
+            'params': '',
+        }
+
+        for op in self.BINARY_OPS:
+            case_data['op'] = '{lane_type}.{op}'.format(lane_type=self.LANE_TYPE, op=op)
+            case_data['extended_name'] = '1st-arg-empty'
+            case_data['params'] = SIMD.v128_const('0', self.LANE_TYPE)
+            cases.append(AssertInvalid.get_arg_empty_test(**case_data))
+
+            case_data['extended_name'] = 'arg-empty'
+            case_data['params'] = ''
+            cases.append(AssertInvalid.get_arg_empty_test(**case_data))
+
+        return '\n'.join(cases)
+
     def get_all_cases(self):
         case_data = {'lane_type': self.LANE_TYPE,
                      'normal_cases': self.get_normal_case(),

--- a/Test/spec/simd/meta/test_assert.py
+++ b/Test/spec/simd/meta/test_assert.py
@@ -12,31 +12,30 @@ TODO: Add more assertions
 # Generate assert_return to test
 class AssertReturn:
 
-    instruction = ''
-    instruction_param = ''
+    op = ''
+    params = ''
     expected_result = ''
 
-    def __init__(self, instruction, instruction_param, expected_result):
-        super(AssertReturn, self).__init__()
+    def __init__(self, op, params, expected_result):
 
         # Convert to list if got str
-        if isinstance(instruction_param, str):
-            instruction_param = [instruction_param]
+        if isinstance(params, str):
+            params = [params]
         if isinstance(expected_result, str):
             expected_result = [expected_result]
 
-        self.instruction = instruction
-        self.instruction_param = instruction_param
+        self.op = op
+        self.params = params
         self.expected_result = expected_result
 
     def __str__(self):
-        assert_return = '(assert_return (invoke "{}"'.format(self.instruction)
+        assert_return = '(assert_return (invoke "{}"'.format(self.op)
 
         head_len = len(assert_return)
 
         # Add write space to make the test case easier to read
         params = []
-        for param in self.instruction_param:
+        for param in self.params:
             white_space = ' '
             if len(params) != 0:
                 white_space = '\n ' + ' ' * head_len
@@ -50,3 +49,32 @@ class AssertReturn:
             results.append(white_space + result)
 
         return '{assert_head}{params}){expected_result})'.format(assert_head=assert_return, params=''.join(params), expected_result=''.join(results))
+
+
+# Generate assert_invalid to test
+class AssertInvalid:
+
+    @staticmethod
+    def get_arg_empty_test(op, extended_name, param_type, result_type, params):
+
+        arg_empty_test = '(assert_invalid' \
+                         '\n  (module' \
+                         '\n    (func ${op}-{extended_name}{param_type}{result_type}' \
+                         '\n      ({op}{params})' \
+                         '\n    )' \
+                         '\n  )' \
+                         '\n  "type mismatch"' \
+                         '\n)'
+
+        def str_with_space(input_str):
+            return (' ' if input_str else '') + input_str
+
+        param_map = {
+            'op': op,
+            'extended_name': extended_name,
+            'param_type': str_with_space(param_type),
+            'result_type': str_with_space(result_type),
+            'params': str_with_space(params),
+        }
+
+        return arg_empty_test.format(**param_map)

--- a/Test/spec/simd/simd_bit_shift.wast
+++ b/Test/spec/simd/simd_bit_shift.wast
@@ -1003,3 +1003,102 @@
 (assert_malformed (module quote "(memory 1) (func (result v128) (f32x4.shl   (v128.const i32x4 0 0 0 0)))") "unknown operator")
 (assert_malformed (module quote "(memory 1) (func (result v128) (f32x4.shr_s (v128.const i32x4 0 0 0 0)))") "unknown operator")
 (assert_malformed (module quote "(memory 1) (func (result v128) (f32x4.shr_u (v128.const i32x4 0 0 0 0)))") "unknown operator")
+
+;; Argument empty
+
+(assert_invalid
+  (module
+    (func $i8x16.shl-1st-arg-empty (result v128)
+      (i8x16.shl (i32.const 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.shl-last-arg-empty (result v128)
+      (i8x16.shl (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.shl-arg-empty (result v128)
+      (i8x16.shl)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.shr_u-1st-arg-empty (result v128)
+      (i16x8.shr_u (i32.const 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.shr_u-last-arg-empty (result v128)
+      (i16x8.shr_u (v128.const i16x8 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.shr_u-arg-empty (result v128)
+      (i16x8.shr_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.shr_s-1st-arg-empty (result v128)
+      (i32x4.shr_s (i32.const 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.shr_s-last-arg-empty (result v128)
+      (i32x4.shr_s (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.shr_s-arg-empty (result v128)
+      (i32x4.shr_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i64x2.shl-1st-arg-empty (result v128)
+      (i64x2.shl (i32.const 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i64x2.shr_u-last-arg-empty (result v128)
+      (i64x2.shr_u (v128.const i64x2 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i64x2.shr_s-arg-empty (result v128)
+      (i64x2.shr_s)
+    )
+  )
+  "type mismatch"
+)

--- a/Test/spec/simd/simd_bitwise.wast
+++ b/Test/spec/simd/simd_bitwise.wast
@@ -710,3 +710,103 @@
 (assert_return (invoke "nested-v128.bitselect"))
 (assert_return (invoke "nested-v128.andnot"))
 (assert_return (invoke "as-param"))
+
+
+;; Argument empty
+
+(assert_invalid
+  (module
+    (func $v128.not-arg-empty (result v128)
+      (v128.not)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $v128.and-1st-arg-empty (result v128)
+      (v128.and (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $v128.and-arg-empty (result v128)
+      (v128.and)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $v128.or-1st-arg-empty (result v128)
+      (v128.or (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $v128.or-arg-empty (result v128)
+      (v128.or)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $v128.xor-1st-arg-empty (result v128)
+      (v128.xor (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $v128.xor-arg-empty (result v128)
+      (v128.xor)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $v128.andnot-1st-arg-empty (result v128)
+      (v128.andnot (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $v128.andnot-arg-empty (result v128)
+      (v128.andnot)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $v128.bitselect-1st-arg-empty (result v128)
+      (v128.bitselect (v128.const i32x4 0 0 0 0) (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $v128.bitselect-two-args-empty (result v128)
+      (v128.bitselect (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $v128.bitselect-arg-empty (result v128)
+      (v128.bitselect)
+    )
+  )
+  "type mismatch"
+)

--- a/Test/spec/simd/simd_boolean.wast
+++ b/Test/spec/simd/simd_boolean.wast
@@ -962,3 +962,54 @@
 (assert_malformed (module quote "(memory 1) (func (result i32) (f32x4.all_true (v128.const i32x4 0 0 0 0)))") "unknown operator")
 (assert_malformed (module quote "(memory 1) (func (result i32) (f64x2.any_true (v128.const i32x4 0 0 0 0)))") "unknown operator")
 (assert_malformed (module quote "(memory 1) (func (result i32) (f64x2.all_true (v128.const i32x4 0 0 0 0)))") "unknown operator")
+
+;; Argument empty
+
+(assert_invalid
+  (module
+    (func $i8x16.any_true-arg-empty (result v128)
+      (i8x16.any_true)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.all_true-arg-empty (result v128)
+      (i8x16.all_true)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.any_true-arg-empty (result v128)
+      (i16x8.any_true)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.all_true-arg-empty (result v128)
+      (i16x8.all_true)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.any_true-arg-empty (result v128)
+      (i32x4.any_true)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.all_true-arg-empty (result v128)
+      (i32x4.all_true)
+    )
+  )
+  "type mismatch"
+)

--- a/Test/spec/simd/simd_conversions.wast
+++ b/Test/spec/simd/simd_conversions.wast
@@ -1488,3 +1488,198 @@
 (assert_return (invoke "i32x4_high_widen_narrow_us" (v128.const i32x4 -0x80000000 -0x7fffffff 0x7fffffff 0x8000000)
                                                     (v128.const i32x4 -0x80000000 -0x7fffffff 0x7fffffff 0x8000000))
                                                     (v128.const i32x4 0x8000 0x8000 0x7fff 0x7fff))
+
+;; Argument empty
+
+(assert_invalid
+  (module
+    (func $i32x4.trunc_sat_f32x4_s-arg-empty (result v128)
+      (i32x4.trunc_sat_f32x4_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.trunc_sat_f32x4_u-arg-empty (result v128)
+      (i32x4.trunc_sat_f32x4_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i64x2.trunc_sat_f64x2_s-arg-empty (result v128)
+      (i64x2.trunc_sat_f64x2_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i64x2.trunc_sat_f64x2_u-arg-empty (result v128)
+      (i64x2.trunc_sat_f64x2_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.convert_i32x4_s-arg-empty (result v128)
+      (f32x4.convert_i32x4_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.convert_i32x4_u-arg-empty (result v128)
+      (f32x4.convert_i32x4_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.convert_i64x2_s-arg-empty (result v128)
+      (f64x2.convert_i64x2_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.convert_i64x2_u-arg-empty (result v128)
+      (f64x2.convert_i64x2_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.narrow_i16x8_s-1st-arg-empty (result v128)
+      (i8x16.narrow_i16x8_s (v128.const i16x8 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.narrow_i16x8_s-arg-empty (result v128)
+      (i8x16.narrow_i16x8_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.narrow_i16x8_u-1st-arg-empty (result v128)
+      (i8x16.narrow_i16x8_u (v128.const i16x8 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.narrow_i16x8_u-arg-empty (result v128)
+      (i8x16.narrow_i16x8_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.narrow_i32x4_s-1st-arg-empty (result v128)
+      (i16x8.narrow_i32x4_s (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.narrow_i32x4_s-arg-empty (result v128)
+      (i16x8.narrow_i32x4_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.narrow_i32x4_u-1st-arg-empty (result v128)
+      (i16x8.narrow_i32x4_u (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.narrow_i32x4_u-arg-empty (result v128)
+      (i16x8.narrow_i32x4_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.widen_high_i8x16_s-arg-empty (result v128)
+      (i16x8.widen_high_i8x16_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.widen_high_i8x16_u-arg-empty (result v128)
+      (i16x8.widen_high_i8x16_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.widen_low_i8x16_s-arg-empty (result v128)
+      (i16x8.widen_low_i8x16_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.widen_low_i8x16_u-arg-empty (result v128)
+      (i16x8.widen_low_i8x16_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.widen_high_i16x8_s-arg-empty (result v128)
+      (i32x4.widen_high_i16x8_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.widen_high_i16x8_u-arg-empty (result v128)
+      (i32x4.widen_high_i16x8_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.widen_low_i16x8_s-arg-empty (result v128)
+      (i32x4.widen_low_i16x8_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.widen_low_i16x8_u-arg-empty (result v128)
+      (i32x4.widen_low_i16x8_u)
+    )
+  )
+  "type mismatch"
+)

--- a/Test/spec/simd/simd_f32x4.wast
+++ b/Test/spec/simd/simd_f32x4.wast
@@ -2337,6 +2337,49 @@
 (assert_invalid (module (func (result v128) (f32x4.min (i32.const 0) (f32.const 0.0)))) "type mismatch")
 (assert_invalid (module (func (result v128) (f32x4.max (i32.const 0) (f32.const 0.0)))) "type mismatch")
 
+;; Argument empty
+
+(assert_invalid
+  (module
+    (func $f32x4.abs-arg-empty (result v128)
+      (f32x4.abs)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.min-1st-arg-empty (result v128)
+      (f32x4.min (v128.const f32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.min-arg-empty (result v128)
+      (f32x4.min)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.max-1st-arg-empty (result v128)
+      (f32x4.max (v128.const f32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.max-arg-empty (result v128)
+      (f32x4.max)
+    )
+  )
+  "type mismatch"
+)
+
 ;; combination
 (module
   (func (export "max-min") (param v128 v128 v128) (result v128)

--- a/Test/spec/simd/simd_f32x4_arith.wast
+++ b/Test/spec/simd/simd_f32x4_arith.wast
@@ -5299,6 +5299,89 @@
 (assert_invalid (module (func (result v128) (f32x4.mul (i32.const 0) (f32.const 0.0)))) "type mismatch")
 (assert_invalid (module (func (result v128) (f32x4.div (i32.const 0) (f32.const 0.0)))) "type mismatch")
 
+;; Argument empty
+
+(assert_invalid
+  (module
+    (func $f32x4.neg-arg-empty (result v128)
+      (f32x4.neg)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.sqrt-arg-empty (result v128)
+      (f32x4.sqrt)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.add-1st-arg-empty (result v128)
+      (f32x4.add (v128.const f32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.add-arg-empty (result v128)
+      (f32x4.add)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.sub-1st-arg-empty (result v128)
+      (f32x4.sub (v128.const f32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.sub-arg-empty (result v128)
+      (f32x4.sub)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.mul-1st-arg-empty (result v128)
+      (f32x4.mul (v128.const f32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.mul-arg-empty (result v128)
+      (f32x4.mul)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.div-1st-arg-empty (result v128)
+      (f32x4.div (v128.const f32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.div-arg-empty (result v128)
+      (f32x4.div)
+    )
+  )
+  "type mismatch"
+)
+
 ;; combination
 (module
   (func (export "add-sub") (param v128 v128 v128) (result v128)

--- a/Test/spec/simd/simd_f32x4_cmp.wast
+++ b/Test/spec/simd/simd_f32x4_cmp.wast
@@ -8066,3 +8066,102 @@
 (assert_return (invoke "nested-gt"))
 (assert_return (invoke "nested-ge"))
 (assert_return (invoke "as-param"))
+
+;; Argument empty
+
+(assert_invalid
+  (module
+    (func $f32x4.eq-1st-arg-empty (result v128)
+      (f32x4.eq (v128.const f32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.eq-arg-empty (result v128)
+      (f32x4.eq)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.ne-1st-arg-empty (result v128)
+      (f32x4.ne (v128.const f32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.ne-arg-empty (result v128)
+      (f32x4.ne)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.lt-1st-arg-empty (result v128)
+      (f32x4.lt (v128.const f32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.lt-arg-empty (result v128)
+      (f32x4.lt)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.le-1st-arg-empty (result v128)
+      (f32x4.le (v128.const f32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.le-arg-empty (result v128)
+      (f32x4.le)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.gt-1st-arg-empty (result v128)
+      (f32x4.gt (v128.const f32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.gt-arg-empty (result v128)
+      (f32x4.gt)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.ge-1st-arg-empty (result v128)
+      (f32x4.ge (v128.const f32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.ge-arg-empty (result v128)
+      (f32x4.ge)
+    )
+  )
+  "type mismatch"
+)

--- a/Test/spec/simd/simd_f64x2.wast
+++ b/Test/spec/simd/simd_f64x2.wast
@@ -2388,6 +2388,49 @@
 (assert_invalid (module (func (result v128) (f64x2.min (i32.const 0) (f32.const 0.0)))) "type mismatch")
 (assert_invalid (module (func (result v128) (f64x2.max (i32.const 0) (f32.const 0.0)))) "type mismatch")
 
+;; Argument empty
+
+(assert_invalid
+  (module
+    (func $f64x2.abs-arg-empty (result v128)
+      (f64x2.abs)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.min-1st-arg-empty (result v128)
+      (f64x2.min (v128.const f64x2 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.min-arg-empty (result v128)
+      (f64x2.min)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.max-1st-arg-empty (result v128)
+      (f64x2.max (v128.const f64x2 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.max-arg-empty (result v128)
+      (f64x2.max)
+    )
+  )
+  "type mismatch"
+)
+
 ;; combination
 (module
   (func (export "max-min") (param v128 v128 v128) (result v128)

--- a/Test/spec/simd/simd_f64x2_arith.wast
+++ b/Test/spec/simd/simd_f64x2_arith.wast
@@ -5306,6 +5306,89 @@
 (assert_invalid (module (func (result v128) (f64x2.mul (i64.const 0) (f64.const 0.0)))) "type mismatch")
 (assert_invalid (module (func (result v128) (f64x2.div (i64.const 0) (f64.const 0.0)))) "type mismatch")
 
+;; Argument empty
+
+(assert_invalid
+  (module
+    (func $f64x2.neg-arg-empty (result v128)
+      (f64x2.neg)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.sqrt-arg-empty (result v128)
+      (f64x2.sqrt)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.add-1st-arg-empty (result v128)
+      (f64x2.add (v128.const f64x2 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.add-arg-empty (result v128)
+      (f64x2.add)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.sub-1st-arg-empty (result v128)
+      (f64x2.sub (v128.const f64x2 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.sub-arg-empty (result v128)
+      (f64x2.sub)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.mul-1st-arg-empty (result v128)
+      (f64x2.mul (v128.const f64x2 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.mul-arg-empty (result v128)
+      (f64x2.mul)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.div-1st-arg-empty (result v128)
+      (f64x2.div (v128.const f64x2 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.div-arg-empty (result v128)
+      (f64x2.div)
+    )
+  )
+  "type mismatch"
+)
+
 ;; combination
 (module
   (func (export "add-sub") (param v128 v128 v128) (result v128)

--- a/Test/spec/simd/simd_f64x2_cmp.wast
+++ b/Test/spec/simd/simd_f64x2_cmp.wast
@@ -7966,6 +7966,105 @@
 (assert_invalid (module (func (result v128) (f64x2.gt (i32.const 0) (f32.const 0.0)))) "type mismatch")
 (assert_invalid (module (func (result v128) (f64x2.ge (i32.const 0) (f32.const 0.0)))) "type mismatch")
 
+;; Argument empty
+
+(assert_invalid
+  (module
+    (func $f64x2.eq-1st-arg-empty (result v128)
+      (f64x2.eq (v128.const f64x2 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.eq-arg-empty (result v128)
+      (f64x2.eq)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.ne-1st-arg-empty (result v128)
+      (f64x2.ne (v128.const f64x2 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.ne-arg-empty (result v128)
+      (f64x2.ne)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.lt-1st-arg-empty (result v128)
+      (f64x2.lt (v128.const f64x2 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.lt-arg-empty (result v128)
+      (f64x2.lt)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.le-1st-arg-empty (result v128)
+      (f64x2.le (v128.const f64x2 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.le-arg-empty (result v128)
+      (f64x2.le)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.gt-1st-arg-empty (result v128)
+      (f64x2.gt (v128.const f64x2 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.gt-arg-empty (result v128)
+      (f64x2.gt)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.ge-1st-arg-empty (result v128)
+      (f64x2.ge (v128.const f64x2 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.ge-arg-empty (result v128)
+      (f64x2.ge)
+    )
+  )
+  "type mismatch"
+)
+
 ;; combination
 (module (memory 1)
   (func (export "f64x2.eq-in-block")

--- a/Test/spec/simd/simd_i16x8_arith.wast
+++ b/Test/spec/simd/simd_i16x8_arith.wast
@@ -530,6 +530,65 @@
 (assert_invalid (module (func (result v128) (i16x8.sub (i32.const 0) (f32.const 0.0)))) "type mismatch")
 (assert_invalid (module (func (result v128) (i16x8.mul (i32.const 0) (f32.const 0.0)))) "type mismatch")
 
+;; Argument empty
+
+(assert_invalid
+  (module
+    (func $i16x8.neg-arg-empty (result v128)
+      (i16x8.neg)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.add-1st-arg-empty (result v128)
+      (i16x8.add (v128.const i16x8 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.add-arg-empty (result v128)
+      (i16x8.add)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.sub-1st-arg-empty (result v128)
+      (i16x8.sub (v128.const i16x8 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.sub-arg-empty (result v128)
+      (i16x8.sub)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.mul-1st-arg-empty (result v128)
+      (i16x8.mul (v128.const i16x8 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.mul-arg-empty (result v128)
+      (i16x8.mul)
+    )
+  )
+  "type mismatch"
+)
+
 ;; combination
 (module
   (func (export "add-sub") (param v128 v128 v128) (result v128)

--- a/Test/spec/simd/simd_i16x8_arith2.wast
+++ b/Test/spec/simd/simd_i16x8_arith2.wast
@@ -242,7 +242,7 @@
 (assert_invalid (module (func (result v128) (i16x8.max_s (i32.const 0) (f32.const 0.0)))) "type mismatch")
 (assert_invalid (module (func (result v128) (i16x8.max_u (i32.const 0) (f32.const 0.0)))) "type mismatch")
 
-;; Test operation with empty argument
+;; Argument empty
 
 (assert_invalid
   (module
@@ -254,7 +254,7 @@
 )
 (assert_invalid
   (module
-    (func $i16x8.min_s-all-args-empty (result v128)
+    (func $i16x8.min_s-arg-empty (result v128)
       (i16x8.min_s)
     )
   )
@@ -270,7 +270,7 @@
 )
 (assert_invalid
   (module
-    (func $i16x8.min_u-all-args-empty (result v128)
+    (func $i16x8.min_u-arg-empty (result v128)
       (i16x8.min_u)
     )
   )
@@ -286,7 +286,7 @@
 )
 (assert_invalid
   (module
-    (func $i16x8.max_s-all-args-empty (result v128)
+    (func $i16x8.max_s-arg-empty (result v128)
       (i16x8.max_s)
     )
   )
@@ -302,7 +302,7 @@
 )
 (assert_invalid
   (module
-    (func $i16x8.max_u-all-args-empty (result v128)
+    (func $i16x8.max_u-arg-empty (result v128)
       (i16x8.max_u)
     )
   )

--- a/Test/spec/simd/simd_i16x8_cmp.wast
+++ b/Test/spec/simd/simd_i16x8_cmp.wast
@@ -1735,3 +1735,167 @@
 (assert_return (invoke "nested-gt_u"))
 (assert_return (invoke "nested-ge_s"))
 (assert_return (invoke "as-param"))
+
+
+;; Argument empty
+
+(assert_invalid
+  (module
+    (func $i16x8.eq-1st-arg-empty (result v128)
+      (i16x8.eq (v128.const i16x8 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.eq-arg-empty (result v128)
+      (i16x8.eq)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.ne-1st-arg-empty (result v128)
+      (i16x8.ne (v128.const i16x8 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.ne-arg-empty (result v128)
+      (i16x8.ne)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.lt_s-1st-arg-empty (result v128)
+      (i16x8.lt_s (v128.const i16x8 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.lt_s-arg-empty (result v128)
+      (i16x8.lt_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.lt_u-1st-arg-empty (result v128)
+      (i16x8.lt_u (v128.const i16x8 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.lt_u-arg-empty (result v128)
+      (i16x8.lt_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.le_s-1st-arg-empty (result v128)
+      (i16x8.le_s (v128.const i16x8 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.le_s-arg-empty (result v128)
+      (i16x8.le_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.le_u-1st-arg-empty (result v128)
+      (i16x8.le_u (v128.const i16x8 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.le_u-arg-empty (result v128)
+      (i16x8.le_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.gt_s-1st-arg-empty (result v128)
+      (i16x8.gt_s (v128.const i16x8 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.gt_s-arg-empty (result v128)
+      (i16x8.gt_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.gt_u-1st-arg-empty (result v128)
+      (i16x8.gt_u (v128.const i16x8 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.gt_u-arg-empty (result v128)
+      (i16x8.gt_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.ge_s-1st-arg-empty (result v128)
+      (i16x8.ge_s (v128.const i16x8 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.ge_s-arg-empty (result v128)
+      (i16x8.ge_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.ge_u-1st-arg-empty (result v128)
+      (i16x8.ge_u (v128.const i16x8 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.ge_u-arg-empty (result v128)
+      (i16x8.ge_u)
+    )
+  )
+  "type mismatch"
+)

--- a/Test/spec/simd/simd_i16x8_sat_arith.wast
+++ b/Test/spec/simd/simd_i16x8_sat_arith.wast
@@ -625,6 +625,73 @@
 (assert_invalid (module (func (result v128) (i16x8.sub_saturate_s (i32.const 0) (f32.const 0.0)))) "type mismatch")
 (assert_invalid (module (func (result v128) (i16x8.sub_saturate_u (i32.const 0) (f32.const 0.0)))) "type mismatch")
 
+;; Argument empty
+
+(assert_invalid
+  (module
+    (func $i16x8.add_saturate_s-1st-arg-empty (result v128)
+      (i16x8.add_saturate_s (v128.const i16x8 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.add_saturate_s-arg-empty (result v128)
+      (i16x8.add_saturate_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.add_saturate_u-1st-arg-empty (result v128)
+      (i16x8.add_saturate_u (v128.const i16x8 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.add_saturate_u-arg-empty (result v128)
+      (i16x8.add_saturate_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.sub_saturate_s-1st-arg-empty (result v128)
+      (i16x8.sub_saturate_s (v128.const i16x8 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.sub_saturate_s-arg-empty (result v128)
+      (i16x8.sub_saturate_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.sub_saturate_u-1st-arg-empty (result v128)
+      (i16x8.sub_saturate_u (v128.const i16x8 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.sub_saturate_u-arg-empty (result v128)
+      (i16x8.sub_saturate_u)
+    )
+  )
+  "type mismatch"
+)
+
 ;; combination
 (module
   (func (export "sat-add_s-sub_s") (param v128 v128 v128) (result v128)

--- a/Test/spec/simd/simd_i32x4_arith.wast
+++ b/Test/spec/simd/simd_i32x4_arith.wast
@@ -530,6 +530,65 @@
 (assert_invalid (module (func (result v128) (i32x4.sub (i32.const 0) (f32.const 0.0)))) "type mismatch")
 (assert_invalid (module (func (result v128) (i32x4.mul (i32.const 0) (f32.const 0.0)))) "type mismatch")
 
+;; Argument empty
+
+(assert_invalid
+  (module
+    (func $i32x4.neg-arg-empty (result v128)
+      (i32x4.neg)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.add-1st-arg-empty (result v128)
+      (i32x4.add (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.add-arg-empty (result v128)
+      (i32x4.add)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.sub-1st-arg-empty (result v128)
+      (i32x4.sub (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.sub-arg-empty (result v128)
+      (i32x4.sub)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.mul-1st-arg-empty (result v128)
+      (i32x4.mul (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.mul-arg-empty (result v128)
+      (i32x4.mul)
+    )
+  )
+  "type mismatch"
+)
+
 ;; combination
 (module
   (func (export "add-sub") (param v128 v128 v128) (result v128)

--- a/Test/spec/simd/simd_i32x4_arith2.wast
+++ b/Test/spec/simd/simd_i32x4_arith2.wast
@@ -252,7 +252,7 @@
 (assert_invalid (module (func (result v128) (i32x4.max_s (i32.const 0) (f32.const 0.0)))) "type mismatch")
 (assert_invalid (module (func (result v128) (i32x4.max_u (i32.const 0) (f32.const 0.0)))) "type mismatch")
 
-;; Test operation with empty argument
+;; Argument empty
 
 (assert_invalid
   (module
@@ -264,7 +264,7 @@
 )
 (assert_invalid
   (module
-    (func $i32x4.min_s-all-args-empty (result v128)
+    (func $i32x4.min_s-arg-empty (result v128)
       (i32x4.min_s)
     )
   )
@@ -280,7 +280,7 @@
 )
 (assert_invalid
   (module
-    (func $i32x4.min_u-all-args-empty (result v128)
+    (func $i32x4.min_u-arg-empty (result v128)
       (i32x4.min_u)
     )
   )
@@ -296,7 +296,7 @@
 )
 (assert_invalid
   (module
-    (func $i32x4.max_s-all-args-empty (result v128)
+    (func $i32x4.max_s-arg-empty (result v128)
       (i32x4.max_s)
     )
   )
@@ -312,7 +312,7 @@
 )
 (assert_invalid
   (module
-    (func $i32x4.max_u-all-args-empty (result v128)
+    (func $i32x4.max_u-arg-empty (result v128)
       (i32x4.max_u)
     )
   )

--- a/Test/spec/simd/simd_i32x4_cmp.wast
+++ b/Test/spec/simd/simd_i32x4_cmp.wast
@@ -1743,6 +1743,168 @@
 (assert_return (invoke "as-param"))
 
 
+;; Argument empty
+
+(assert_invalid
+  (module
+    (func $i32x4.eq-1st-arg-empty (result v128)
+      (i32x4.eq (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.eq-arg-empty (result v128)
+      (i32x4.eq)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.ne-1st-arg-empty (result v128)
+      (i32x4.ne (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.ne-arg-empty (result v128)
+      (i32x4.ne)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.lt_s-1st-arg-empty (result v128)
+      (i32x4.lt_s (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.lt_s-arg-empty (result v128)
+      (i32x4.lt_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.lt_u-1st-arg-empty (result v128)
+      (i32x4.lt_u (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.lt_u-arg-empty (result v128)
+      (i32x4.lt_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.le_s-1st-arg-empty (result v128)
+      (i32x4.le_s (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.le_s-arg-empty (result v128)
+      (i32x4.le_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.le_u-1st-arg-empty (result v128)
+      (i32x4.le_u (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.le_u-arg-empty (result v128)
+      (i32x4.le_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.gt_s-1st-arg-empty (result v128)
+      (i32x4.gt_s (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.gt_s-arg-empty (result v128)
+      (i32x4.gt_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.gt_u-1st-arg-empty (result v128)
+      (i32x4.gt_u (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.gt_u-arg-empty (result v128)
+      (i32x4.gt_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.ge_s-1st-arg-empty (result v128)
+      (i32x4.ge_s (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.ge_s-arg-empty (result v128)
+      (i32x4.ge_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.ge_u-1st-arg-empty (result v128)
+      (i32x4.ge_u (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.ge_u-arg-empty (result v128)
+      (i32x4.ge_u)
+    )
+  )
+  "type mismatch"
+)
 ;; Unknown operators
 
 (assert_malformed (module quote "(memory 1) (func (param $x v128) (param $y v128) (result v128) (i4x32.eq (local.get $x) (local.get $y)))") "unknown operator")
@@ -1755,3 +1917,4 @@
 (assert_malformed (module quote "(memory 1) (func (param $x v128) (param $y v128) (result v128) (i4x32.gt_u (local.get $x) (local.get $y)))") "unknown operator")
 (assert_malformed (module quote "(memory 1) (func (param $x v128) (param $y v128) (result v128) (i4x32.ge_s (local.get $x) (local.get $y)))") "unknown operator")
 (assert_malformed (module quote "(memory 1) (func (param $x v128) (param $y v128) (result v128) (i4x32.ge_u (local.get $x) (local.get $y)))") "unknown operator")
+

--- a/Test/spec/simd/simd_i64x2_arith.wast
+++ b/Test/spec/simd/simd_i64x2_arith.wast
@@ -548,6 +548,65 @@
 (assert_invalid (module (func (result v128) (i64x2.sub (i32.const 0) (f32.const 0.0)))) "type mismatch")
 (assert_invalid (module (func (result v128) (i64x2.mul (i32.const 0) (f32.const 0.0)))) "type mismatch")
 
+;; Argument empty
+
+(assert_invalid
+  (module
+    (func $i64x2.neg-arg-empty (result v128)
+      (i64x2.neg)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i64x2.add-1st-arg-empty (result v128)
+      (i64x2.add (v128.const i64x2 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i64x2.add-arg-empty (result v128)
+      (i64x2.add)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i64x2.sub-1st-arg-empty (result v128)
+      (i64x2.sub (v128.const i64x2 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i64x2.sub-arg-empty (result v128)
+      (i64x2.sub)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i64x2.mul-1st-arg-empty (result v128)
+      (i64x2.mul (v128.const i64x2 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i64x2.mul-arg-empty (result v128)
+      (i64x2.mul)
+    )
+  )
+  "type mismatch"
+)
+
 ;; combination
 (module
   (func (export "add-sub") (param v128 v128 v128) (result v128)

--- a/Test/spec/simd/simd_i8x16_arith.wast
+++ b/Test/spec/simd/simd_i8x16_arith.wast
@@ -355,6 +355,49 @@
 (assert_invalid (module (func (result v128) (i8x16.add (i32.const 0) (f32.const 0.0)))) "type mismatch")
 (assert_invalid (module (func (result v128) (i8x16.sub (i32.const 0) (f32.const 0.0)))) "type mismatch")
 
+;; Argument empty
+
+(assert_invalid
+  (module
+    (func $i8x16.neg-arg-empty (result v128)
+      (i8x16.neg)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.add-1st-arg-empty (result v128)
+      (i8x16.add (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.add-arg-empty (result v128)
+      (i8x16.add)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.sub-1st-arg-empty (result v128)
+      (i8x16.sub (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.sub-arg-empty (result v128)
+      (i8x16.sub)
+    )
+  )
+  "type mismatch"
+)
+
 ;; combination
 (module
   (func (export "add-sub") (param v128 v128 v128) (result v128)

--- a/Test/spec/simd/simd_i8x16_arith2.wast
+++ b/Test/spec/simd/simd_i8x16_arith2.wast
@@ -242,7 +242,7 @@
 (assert_invalid (module (func (result v128) (i8x16.max_s (i32.const 0) (f32.const 0.0)))) "type mismatch")
 (assert_invalid (module (func (result v128) (i8x16.max_u (i32.const 0) (f32.const 0.0)))) "type mismatch")
 
-;; Test operation with empty argument
+;; Argument empty
 
 (assert_invalid
   (module
@@ -254,7 +254,7 @@
 )
 (assert_invalid
   (module
-    (func $i8x16.min_s-all-args-empty (result v128)
+    (func $i8x16.min_s-arg-empty (result v128)
       (i8x16.min_s)
     )
   )
@@ -270,7 +270,7 @@
 )
 (assert_invalid
   (module
-    (func $i8x16.min_u-all-args-empty (result v128)
+    (func $i8x16.min_u-arg-empty (result v128)
       (i8x16.min_u)
     )
   )
@@ -286,7 +286,7 @@
 )
 (assert_invalid
   (module
-    (func $i8x16.max_s-all-args-empty (result v128)
+    (func $i8x16.max_s-arg-empty (result v128)
       (i8x16.max_s)
     )
   )
@@ -302,7 +302,7 @@
 )
 (assert_invalid
   (module
-    (func $i8x16.max_u-all-args-empty (result v128)
+    (func $i8x16.max_u-arg-empty (result v128)
       (i8x16.max_u)
     )
   )

--- a/Test/spec/simd/simd_i8x16_cmp.wast
+++ b/Test/spec/simd/simd_i8x16_cmp.wast
@@ -1682,3 +1682,166 @@
 (assert_return (invoke "nested-ge_s"))
 (assert_return (invoke "as-param"))
 
+
+;; Argument empty
+
+(assert_invalid
+  (module
+    (func $i8x16.eq-1st-arg-empty (result v128)
+      (i8x16.eq (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.eq-arg-empty (result v128)
+      (i8x16.eq)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.ne-1st-arg-empty (result v128)
+      (i8x16.ne (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.ne-arg-empty (result v128)
+      (i8x16.ne)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.lt_s-1st-arg-empty (result v128)
+      (i8x16.lt_s (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.lt_s-arg-empty (result v128)
+      (i8x16.lt_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.lt_u-1st-arg-empty (result v128)
+      (i8x16.lt_u (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.lt_u-arg-empty (result v128)
+      (i8x16.lt_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.le_s-1st-arg-empty (result v128)
+      (i8x16.le_s (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.le_s-arg-empty (result v128)
+      (i8x16.le_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.le_u-1st-arg-empty (result v128)
+      (i8x16.le_u (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.le_u-arg-empty (result v128)
+      (i8x16.le_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.gt_s-1st-arg-empty (result v128)
+      (i8x16.gt_s (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.gt_s-arg-empty (result v128)
+      (i8x16.gt_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.gt_u-1st-arg-empty (result v128)
+      (i8x16.gt_u (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.gt_u-arg-empty (result v128)
+      (i8x16.gt_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.ge_s-1st-arg-empty (result v128)
+      (i8x16.ge_s (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.ge_s-arg-empty (result v128)
+      (i8x16.ge_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.ge_u-1st-arg-empty (result v128)
+      (i8x16.ge_u (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.ge_u-arg-empty (result v128)
+      (i8x16.ge_u)
+    )
+  )
+  "type mismatch"
+)

--- a/Test/spec/simd/simd_i8x16_sat_arith.wast
+++ b/Test/spec/simd/simd_i8x16_sat_arith.wast
@@ -601,6 +601,73 @@
 (assert_invalid (module (func (result v128) (i8x16.sub_saturate_s (i32.const 0) (f32.const 0.0)))) "type mismatch")
 (assert_invalid (module (func (result v128) (i8x16.sub_saturate_u (i32.const 0) (f32.const 0.0)))) "type mismatch")
 
+;; Argument empty
+
+(assert_invalid
+  (module
+    (func $i8x16.add_saturate_s-1st-arg-empty (result v128)
+      (i8x16.add_saturate_s (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.add_saturate_s-arg-empty (result v128)
+      (i8x16.add_saturate_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.add_saturate_u-1st-arg-empty (result v128)
+      (i8x16.add_saturate_u (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.add_saturate_u-arg-empty (result v128)
+      (i8x16.add_saturate_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.sub_saturate_s-1st-arg-empty (result v128)
+      (i8x16.sub_saturate_s (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.sub_saturate_s-arg-empty (result v128)
+      (i8x16.sub_saturate_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.sub_saturate_u-1st-arg-empty (result v128)
+      (i8x16.sub_saturate_u (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.sub_saturate_u-arg-empty (result v128)
+      (i8x16.sub_saturate_u)
+    )
+  )
+  "type mismatch"
+)
+
 ;; combination
 (module
   (func (export "sat-add_s-sub_s") (param v128 v128 v128) (result v128)

--- a/Test/spec/simd/simd_lane.wast
+++ b/Test/spec/simd/simd_lane.wast
@@ -846,3 +846,150 @@
 
 (assert_return (invoke "as-local_set-value-1" (v128.const i64x2 -1 -1)) (i64.const -1))
 (assert_return (invoke "as-global_set-value-3" (v128.const f64x2 0 0)(f64.const 3.14)) (v128.const f64x2 3.14 0))
+
+;; Argument empty
+
+(assert_invalid
+  (module
+    (func $i8x16.extract_lane_s-1st-arg-empty (result i32)
+      (i8x16.extract_lane_s (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.extract_lane_s-2nd-arg-empty (result i32)
+      (i8x16.extract_lane_s 0)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i8x16.extract_lane_s-arg-empty (result i32)
+      (i8x16.extract_lane_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.extract_lane_u-1st-arg-empty (result i32)
+      (i16x8.extract_lane_u (v128.const i16x8 0 0 0 0 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.extract_lane_u-2nd-arg-empty (result i32)
+      (i16x8.extract_lane_u 0)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.extract_lane_u-arg-empty (result i32)
+      (i16x8.extract_lane_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.extract_lane-1st-arg-empty (result i32)
+      (i32x4.extract_lane (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.extract_lane-2nd-arg-empty (result i32)
+      (i32x4.extract_lane 0)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.extract_lane-arg-empty (result i32)
+      (i32x4.extract_lane)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i64x2.extract_lane-1st-arg-empty (result i64)
+      (i64x2.extract_lane (v128.const i64x2 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i64x2.extract_lane-2nd-arg-empty (result i64)
+      (i64x2.extract_lane 0)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i64x2.extract_lane-arg-empty (result i64)
+      (i64x2.extract_lane)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.extract_lane-1st-arg-empty (result f32)
+      (f32x4.extract_lane (v128.const f32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.extract_lane-2nd-arg-empty (result f32)
+      (f32x4.extract_lane 0)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.extract_lane-arg-empty (result f32)
+      (f32x4.extract_lane)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.extract_lane-1st-arg-empty (result f64)
+      (f64x2.extract_lane (v128.const f64x2 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.extract_lane-2nd-arg-empty (result f64)
+      (f64x2.extract_lane 0)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.extract_lane-arg-empty (result f64)
+      (f64x2.extract_lane)
+    )
+  )
+  "type mismatch"
+)

--- a/Test/spec/simd/simd_load.wast
+++ b/Test/spec/simd/simd_load.wast
@@ -182,3 +182,31 @@
   (module (memory 1) (func (drop (v128.load (local.get 2)))))
   "unknown local 2"
 )
+
+
+;; Argument empty
+
+(assert_invalid
+  (module
+    (func $v128.const-arg-empty (result v128)
+      (v128.const)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $v128.const-1st-arg-empty (result v128)
+      (v128.const 0 0 0 0)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $v128.const-2nd-arg-empty (result v128)
+      (v128.const i32x4)
+    )
+  )
+  "type mismatch"
+)

--- a/Test/spec/simd/simd_load_extend.wast
+++ b/Test/spec/simd/simd_load_extend.wast
@@ -220,7 +220,59 @@
 (assert_invalid (module (memory 0) (func (result v128) (i64x2.load32x2_s (v128.const i32x4 0 0 0 0)))) "type mismatch")
 (assert_invalid (module (memory 0) (func (result v128) (i64x2.load32x2_u (v128.const i32x4 0 0 0 0)))) "type mismatch")
 
-;; unknown operator
+;; Argument empty
+
+(assert_invalid
+  (module (memory 0)
+    (func $i16x8.load8x8_s-arg-empty (result v128)
+      (i16x8.load8x8_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module (memory 0)
+    (func $i16x8.load8x8_u-arg-empty (result v128)
+      (i16x8.load8x8_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module (memory 0)
+    (func $i32x4.load16x4_s-arg-empty (result v128)
+      (i32x4.load16x4_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module (memory 0)
+    (func $i32x4.load16x4_u-arg-empty (result v128)
+      (i32x4.load16x4_u)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module (memory 0)
+    (func $i64x2.load32x2_s-arg-empty (result v128)
+      (i64x2.load32x2_s)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module (memory 0)
+    (func $i64x2.load32x2_u-arg-empty (result v128)
+      (i64x2.load32x2_u)
+    )
+  )
+  "type mismatch"
+)
+
+;; Unknown operator
+
 (assert_malformed (module quote "(memory 1) (func (drop (i16x8.load16x4_s (i32.const 0))))") "unknown operator")
 (assert_malformed (module quote "(memory 1) (func (drop (i16x8.load16x4_u (i32.const 0))))") "unknown operator")
 (assert_malformed (module quote "(memory 1) (func (drop (i32x4.load32x2_s (i32.const 0))))") "unknown operator")

--- a/Test/spec/simd/simd_load_splat.wast
+++ b/Test/spec/simd/simd_load_splat.wast
@@ -218,3 +218,39 @@
 (assert_malformed (module quote "(memory 1) (func (drop (i16x8.load_splat (i32.const 0))))") "unknown operator")
 (assert_malformed (module quote "(memory 1) (func (drop (i32x4.load_splat (i32.const 0))))") "unknown operator")
 (assert_malformed (module quote "(memory 1) (func (drop (i64x2.load_splat (i32.const 0))))") "unknown operator")
+
+
+;; Argument empty
+
+(assert_invalid
+  (module (memory 0)
+    (func $v8x16.load_splat-arg-empty (result v128)
+      (v8x16.load_splat)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module (memory 0)
+    (func $v16x8.load_splat-arg-empty (result v128)
+      (v16x8.load_splat)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module (memory 0)
+    (func $v32x4.load_splat-arg-empty (result v128)
+      (v32x4.load_splat)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module (memory 0)
+    (func $v64x2.load_splat-arg-empty (result v128)
+      (v64x2.load_splat)
+    )
+  )
+  "type mismatch"
+)

--- a/Test/spec/simd/simd_splat.wast
+++ b/Test/spec/simd/simd_splat.wast
@@ -376,3 +376,55 @@
 (assert_return (invoke "as-return-value2" (i64.const 0xABCD)) (v128.const i64x2 0xABCD 0xABCD))
 (assert_return (invoke "as-local_set-value2" (i64.const 0x10000)) (v128.const i64x2 0x10000 0x10000))
 (assert_return (invoke "as-global_set-value2" (f64.const 1.0)) (v128.const f64x2 1.0 1.0))
+
+
+;; Argument empty
+
+(assert_invalid
+  (module
+    (func $i8x16.splat-arg-empty (result v128)
+      (i8x16.splat)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.splat-arg-empty (result v128)
+      (i16x8.splat)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.splat-arg-empty (result v128)
+      (i32x4.splat)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.splat-arg-empty (result v128)
+      (f32x4.splat)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i64x2.splat-arg-empty (result v128)
+      (i64x2.splat)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.splat-arg-empty (result v128)
+      (f64x2.splat)
+    )
+  )
+  "type mismatch"
+)

--- a/Test/spec/simd/simd_store.wast
+++ b/Test/spec/simd/simd_store.wast
@@ -136,3 +136,31 @@
   (module (memory 1) (func (result v128) (v128.store (i32.const 0) (v128.const i32x4 0 0 0 0))))
   "type mismatch"
 )
+
+
+;; Argument empty
+
+(assert_invalid
+  (module (memory 0)
+    (func $v128.store-1st-arg-empty
+      (v128.store (v128.const i32x4 0 0 0 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module (memory 0)
+    (func $v128.store-2nd-arg-empty
+      (v128.store (i32.const 0))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module (memory 0)
+    (func $v128.store-arg-empty
+      (v128.store)
+    )
+  )
+  "type mismatch"
+)


### PR DESCRIPTION
This PR adds spec tests for testing all simd ops with missing arguments.