### PR TITLE
[simd] Simplify the use of formatting AssertReturn statements

### DIFF
--- a/Test/spec/simd/meta/simd_arithmetic.py
+++ b/Test/spec/simd/meta/simd_arithmetic.py
@@ -258,39 +258,16 @@ class SimdArithmeticCase:
                                                            op1=func_parts[0],
                                                            op2=func_parts[1]))
         combine_cases.append(')\n')
-        ternary_case_template = ('(assert_return (invoke "{func}" ',
-                                 '(v128.const {lane_type_1} {val_1})',
-                                 '(v128.const {lane_type_2} {val_2})',
-                                 '(v128.const {lane_type_3} {val_3}))',
-                                 '(v128.const {lane_type_4} {val_4}))')
+
         for func, test in sorted(self.combine_ternary_arith_test_data.items()):
-            line_head = ternary_case_template[0].format(func=func)
-            line_head_len = len(line_head)
-            blank_head = ' ' * line_head_len
-            combine_cases.append('\n'.join([
-                line_head + ternary_case_template[1].format(
-                    lane_type_1=self.LANE_TYPE, val_1=' '.join(test[0])),
-                blank_head + ternary_case_template[2].format(
-                    lane_type_2=self.LANE_TYPE, val_2=' '.join(test[1])),
-                blank_head + ternary_case_template[3].format(
-                    lane_type_3=self.LANE_TYPE, val_3=' '.join(test[2])),
-                blank_head + ternary_case_template[4].format(
-                    lane_type_4=self.LANE_TYPE, val_4=' '.join(test[3]))]))
-        binary_case_template = ('(assert_return (invoke "{func}" ',
-                                '(v128.const {lane_type_1} {val_1})',
-                                '(v128.const {lane_type_2} {val_2}))',
-                                '(v128.const {lane_type_3} {val_3}))')
+            combine_cases.append(str(AssertReturn(func,
+                                 [SIMD.v128_const(elem, self.LANE_TYPE) for elem in test[:-1]],
+                                 SIMD.v128_const(test[-1], self.LANE_TYPE))))
         for func, test in sorted(self.combine_binary_arith_test_data.items()):
-            line_head = binary_case_template[0].format(func=func)
-            line_head_len = len(line_head)
-            blank_head = ' ' * line_head_len
-            combine_cases.append('\n'.join([
-                line_head + binary_case_template[1].format(
-                    lane_type_1=self.LANE_TYPE, val_1=' '.join(test[0])),
-                blank_head + binary_case_template[2].format(
-                    lane_type_2=self.LANE_TYPE, val_2=' '.join(test[1])),
-                blank_head + binary_case_template[3].format(
-                    lane_type_3=self.LANE_TYPE, val_3=' '.join(test[2]))]))
+            combine_cases.append(str(AssertReturn(func,
+                                 [SIMD.v128_const(elem, self.LANE_TYPE) for elem in test[:-1]],
+                                 SIMD.v128_const(test[-1], self.LANE_TYPE))))
+
         return '\n'.join(combine_cases)
 
     def get_normal_case(self):

--- a/Test/spec/simd/meta/simd_f32x4.py
+++ b/Test/spec/simd/meta/simd_f32x4.py
@@ -249,38 +249,40 @@ class Simdf32x4Case(Simdf32x4ArithmeticCase):
 
         for op in self.BINARY_OPS:
             op_name = self.full_op_name(op)
-            for p1 in self.FLOAT_NUMBERS:
-                for p2 in self.FLOAT_NUMBERS:
-                    result = self.floatOp.binary_op(op, p1, p2)
+            for operand1 in self.FLOAT_NUMBERS:
+                for operand2 in self.FLOAT_NUMBERS:
+                    result = self.floatOp.binary_op(op, operand1, operand2)
                     if 'nan' not in result:
                         # Normal floating point numbers as the results
-                        binary_test_data.append(['assert_return', op_name, p1, p2, result])
+                        binary_test_data.append([op_name, operand1, operand2, result])
                     else:
                         # Since the results contain the 'nan' string, the result literals would be
                         # nan:canonical
-                        binary_test_data.append(['assert_return', op_name, p1, p2, 'nan:canonical'])
+                        binary_test_data.append([op_name, operand1, operand2, 'nan:canonical'])
 
-            for p1 in self.LITERAL_NUMBERS:
-                for p2 in self.LITERAL_NUMBERS:
-                    result = self.floatOp.binary_op(op, p1, p2, hex_form=False)
-                    binary_test_data.append(['assert_return', op_name, p1, p2, result])
+            for operand1 in self.LITERAL_NUMBERS:
+                for operand2 in self.LITERAL_NUMBERS:
+                    result = self.floatOp.binary_op(op, operand1, operand2, hex_form=False)
+                    binary_test_data.append([op_name, operand1, operand2, result])
 
-            for p1 in self.NAN_NUMBERS:
-                for p2 in self.FLOAT_NUMBERS:
-                    if 'nan:' in p1 or 'nan:' in p2:
+            for operand1 in self.NAN_NUMBERS:
+                for operand2 in self.FLOAT_NUMBERS:
+                    if 'nan:' in operand1 or 'nan:' in operand2:
                         # When the arguments contain 'nan:', the result literal is nan:arithmetic
-                        binary_test_data.append(['assert_return', op_name, p1, p2, 'nan:arithmetic'])
+                        binary_test_data.append([op_name, operand1, operand2, 'nan:arithmetic'])
                     else:
                         # No 'nan' string found, then the result literal is nan:canonical
-                        binary_test_data.append(['assert_return', op_name, p1, p2, 'nan:canonical'])
-                for p2 in self.NAN_NUMBERS:
-                    if 'nan:' in p1 or 'nan:' in p2:
-                        binary_test_data.append(['assert_return', op_name, p1, p2, 'nan:arithmetic'])
+                        binary_test_data.append([op_name, operand1, operand2, 'nan:canonical'])
+                for operand2 in self.NAN_NUMBERS:
+                    if 'nan:' in operand1 or 'nan:' in operand2:
+                        binary_test_data.append([op_name, operand1, operand2, 'nan:arithmetic'])
                     else:
-                        binary_test_data.append(['assert_return', op_name, p1, p2, 'nan:canonical'])
+                        binary_test_data.append([op_name, operand1, operand2, 'nan:canonical'])
 
         for case in binary_test_data:
-            cases.append(self.single_binary_test(case))
+            cases.append(str(AssertReturn(case[0],
+                        [SIMD.v128_const(c, self.LANE_TYPE) for c in case[1:-1]],
+                        SIMD.v128_const(case[-1], self.LANE_TYPE))))
 
         # Test opposite signs of zero
         lst_oppo_signs_0 = [
@@ -324,17 +326,19 @@ class Simdf32x4Case(Simdf32x4ArithmeticCase):
                                            self.v128_const(case_data[3][1], case_data[1][1])],
                                           self.v128_const(case_data[3][2], case_data[2][0]))))
 
-        for p in self.FLOAT_NUMBERS + self.LITERAL_NUMBERS:
+        for operand in self.FLOAT_NUMBERS + self.LITERAL_NUMBERS:
             op_name = self.full_op_name('abs')
             hex_literal = True
-            if p in self.LITERAL_NUMBERS:
+            if operand in self.LITERAL_NUMBERS:
                 hex_literal = False
-            result = self.floatOp.unary_op('abs', p, hex_form=hex_literal)
+            result = self.floatOp.unary_op('abs', operand, hex_form=hex_literal)
             # Abs operation is valid for all the floating point numbers
-            unary_test_data.append(['assert_return', op_name, p, result])
+            unary_test_data.append([op_name, operand, result])
 
         for case in unary_test_data:
-            cases.append(self.single_unary_test(case))
+            cases.append(str(AssertReturn(case[0],
+                        [SIMD.v128_const(elem, self.LANE_TYPE) for elem in case[1:-1]],
+                        SIMD.v128_const(case[-1], self.LANE_TYPE))))
 
         self.get_unknown_operator_case(cases)
 

--- a/Test/spec/simd/meta/simd_f64x2.py
+++ b/Test/spec/simd/meta/simd_f64x2.py
@@ -7,6 +7,7 @@ Generate f64x2 [abs, min, max] cases.
 from simd_f32x4 import Simdf32x4Case
 from simd_f32x4_arith import Simdf32x4ArithmeticCase
 from test_assert import AssertReturn
+from simd import SIMD
 
 
 class Simdf64x2Case(Simdf32x4Case):
@@ -272,38 +273,40 @@ class Simdf64x2Case(Simdf32x4Case):
 
         for op in self.BINARY_OPS:
             op_name = self.full_op_name(op)
-            for p1 in self.FLOAT_NUMBERS:
-                for p2 in self.FLOAT_NUMBERS:
-                    result = self.floatOp.binary_op(op, p1, p2)
+            for operand1 in self.FLOAT_NUMBERS:
+                for operand2 in self.FLOAT_NUMBERS:
+                    result = self.floatOp.binary_op(op, operand1, operand2)
                     if 'nan' not in result:
                         # Normal floating point numbers as the results
-                        binary_test_data.append(['assert_return', op_name, p1, p2, result])
+                        binary_test_data.append([op_name, operand1, operand2, result])
                     else:
                         # Since the results contain the 'nan' string, the result literals would be
                         # nan:canonical
-                        binary_test_data.append(['assert_return', op_name, p1, p2, 'nan:canonical'])
+                        binary_test_data.append([op_name, operand1, operand2, 'nan:canonical'])
 
-            for p1 in self.NAN_NUMBERS:
-                for p2 in self.FLOAT_NUMBERS:
-                    if 'nan:' in p1 or 'nan:' in p2:
+            for operand1 in self.NAN_NUMBERS:
+                for operand2 in self.FLOAT_NUMBERS:
+                    if 'nan:' in operand1 or 'nan:' in operand2:
                         # When the arguments contain 'nan:', the result literal is nan:arithmetic
-                        binary_test_data.append(['assert_return', op_name, p1, p2, 'nan:arithmetic'])
+                        binary_test_data.append([op_name, operand1, operand2, 'nan:arithmetic'])
                     else:
                         # No 'nan' string found, then the result literal is nan:canonical
-                        binary_test_data.append(['assert_return', op_name, p1, p2, 'nan:canonical'])
-                for p2 in self.NAN_NUMBERS:
-                    if 'nan:' in p1 or 'nan:' in p2:
-                        binary_test_data.append(['assert_return', op_name, p1, p2, 'nan:arithmetic'])
+                        binary_test_data.append([op_name, operand1, operand2, 'nan:canonical'])
+                for operand2 in self.NAN_NUMBERS:
+                    if 'nan:' in operand1 or 'nan:' in operand2:
+                        binary_test_data.append([op_name, operand1, operand2, 'nan:arithmetic'])
                     else:
-                        binary_test_data.append(['assert_return', op_name, p1, p2, 'nan:canonical'])
+                        binary_test_data.append([op_name, operand1, operand2, 'nan:canonical'])
 
-            for p1 in self.LITERAL_NUMBERS:
-                for p2 in self.LITERAL_NUMBERS:
-                    result = self.floatOp.binary_op(op, p1, p2, hex_form=False)
-                    binary_test_data.append(['assert_return', op_name, p1, p2, result])
+            for operand1 in self.LITERAL_NUMBERS:
+                for operand2 in self.LITERAL_NUMBERS:
+                    result = self.floatOp.binary_op(op, operand1, operand2, hex_form=False)
+                    binary_test_data.append([op_name, operand1, operand2, result])
 
         for case in binary_test_data:
-            cases.append(self.single_binary_test(case))
+            cases.append(str(AssertReturn(case[0],
+                        [SIMD.v128_const(elem, self.LANE_TYPE) for elem in case[1:-1]],
+                        SIMD.v128_const(case[-1], self.LANE_TYPE))))
 
         # Test opposite signs of zero
         lst_oppo_signs_0 = [
@@ -366,10 +369,12 @@ class Simdf64x2Case(Simdf32x4Case):
                 hex_literal = False
             result = self.floatOp.unary_op('abs', p, hex_form=hex_literal)
             # Abs operation is valid for all the floating point numbers
-            unary_test_data.append(['assert_return', op_name, p, result])
+            unary_test_data.append([ op_name, p, result])
 
         for case in unary_test_data:
-            cases.append(self.single_unary_test(case))
+            cases.append(str(AssertReturn(case[0],
+                        [SIMD.v128_const(c, self.LANE_TYPE) for c in case[1:-1]],
+                        SIMD.v128_const(case[-1], self.LANE_TYPE))))
 
         return '\n'.join(cases)
 

--- a/Test/spec/simd/meta/simd_sat_arith.py
+++ b/Test/spec/simd/meta/simd_sat_arith.py
@@ -5,6 +5,8 @@ Generate saturating integer arithmetic operation cases.
 """
 
 from simd_arithmetic import SimdArithmeticCase
+from test_assert import AssertReturn
+from simd import SIMD
 
 
 class SimdSaturateArithmeticCases(SimdArithmeticCase):
@@ -153,39 +155,17 @@ class SimdSaturateArithmeticCases(SimdArithmeticCase):
                                                            op1=op1,
                                                            op2=func_parts[2]))
         combine_cases.append(')\n')
-        ternary_case_template = ('(assert_return (invoke "{func}" ',
-                                 '(v128.const {lane_type_1} {val_1})',
-                                 '(v128.const {lane_type_2} {val_2})',
-                                 '(v128.const {lane_type_3} {val_3}))',
-                                 '(v128.const {lane_type_4} {val_4}))')
+
         for func, test in sorted(self.combine_ternary_arith_test_data.items()):
-            line_head = ternary_case_template[0].format(func=func)
-            line_head_len = len(line_head)
-            blank_head = ' ' * line_head_len
-            combine_cases.append('\n'.join([
-                line_head + ternary_case_template[1].format(
-                    lane_type_1=self.LANE_TYPE, val_1=' '.join(test[0])),
-                blank_head + ternary_case_template[2].format(
-                    lane_type_2=self.LANE_TYPE, val_2=' '.join(test[1])),
-                blank_head + ternary_case_template[3].format(
-                    lane_type_3=self.LANE_TYPE, val_3=' '.join(test[2])),
-                blank_head + ternary_case_template[4].format(
-                    lane_type_4=self.LANE_TYPE, val_4=' '.join(test[3]))]))
-        binary_case_template = ('(assert_return (invoke "{func}" ',
-                                '(v128.const {lane_type_1} {val_1})',
-                                '(v128.const {lane_type_2} {val_2}))',
-                                '(v128.const {lane_type_3} {val_3}))')
+            combine_cases.append(str(AssertReturn(func,
+                                 [SIMD.v128_const(elem, self.LANE_TYPE) for elem in test[:-1]],
+                                 SIMD.v128_const(test[-1], self.LANE_TYPE))))
+
         for func, test in sorted(self.combine_binary_arith_test_data.items()):
-            line_head = binary_case_template[0].format(func=func)
-            line_head_len = len(line_head)
-            blank_head = ' ' * line_head_len
-            combine_cases.append('\n'.join([
-                line_head + binary_case_template[1].format(
-                    lane_type_1=self.LANE_TYPE, val_1=' '.join(test[0])),
-                blank_head + binary_case_template[2].format(
-                    lane_type_2=self.LANE_TYPE, val_2=' '.join(test[1])),
-                blank_head + binary_case_template[3].format(
-                    lane_type_3=self.LANE_TYPE, val_3=' '.join(test[2]))]))
+            combine_cases.append(str(AssertReturn(func,
+                                 [SIMD.v128_const(elem, self.LANE_TYPE) for elem in test[:-1]],
+                                 SIMD.v128_const(test[-1], self.LANE_TYPE))))
+
         return '\n'.join(combine_cases)
 
 


### PR DESCRIPTION
- Remove the duplicate methods to format AssertReturn statements in
  multiple lines. Use the united format methods of AssertReturn class
  in test_assert.py.
- Use more descriptive param names.