### PR TITLE
Fix the utf-8 form check issue

### DIFF
--- a/Include/WAVM/Inline/Unicode.h
+++ b/Include/WAVM/Inline/Unicode.h
@@ -58,7 +58,7 @@ namespace WAVM { namespace Unicode {
 			}
 			else if(*nextChar == 0xed)
 			{
-				if(nextChar + 2 >= endChar || nextChar[1] < 0xa0 || nextChar[1] > 0x9f
+				if(nextChar + 2 >= endChar || nextChar[1] < 0x80 || nextChar[1] > 0x9f
 				   || nextChar[2] < 0x80 || nextChar[2] > 0xbf)
 				{ return false; }
 			}


### PR DESCRIPTION
From table 3-7 in the Unicode Standard 9.0, the valid range of the second byte should be [0x80, 0x9F] when the first byte is 0xED.