### PR TITLE
GC: Only consider references to instance's functions

### DIFF
--- a/Lib/Runtime/ObjectGC.cpp
+++ b/Lib/Runtime/ObjectGC.cpp
@@ -194,7 +194,8 @@ static bool collectGarbageImpl(Compartment* compartment)
 			bool hasRootFunction = false;
 			for(Function* function : instance->functions)
 			{
-				if(function && function->mutableData->numRootReferences && function->instanceId == instance->id)
+				if(function && function->mutableData->numRootReferences
+				   && function->instanceId == instance->id)
 				{
 					hasRootFunction = true;
 					break;

--- a/Lib/Runtime/ObjectGC.cpp
+++ b/Lib/Runtime/ObjectGC.cpp
@@ -194,7 +194,7 @@ static bool collectGarbageImpl(Compartment* compartment)
 			bool hasRootFunction = false;
 			for(Function* function : instance->functions)
 			{
-				if(function && function->mutableData->numRootReferences)
+				if(function && function->mutableData->numRootReferences && function->instanceId == instance->id)
 				{
 					hasRootFunction = true;
 					break;


### PR DESCRIPTION
Proposal: **GC no longer considers references to imported functions as references to a module**

**Background & issue:**
When trying to link two modules together and then unlink them I noticed that memory keeps increasing even if I link and unlink the same module.
Debugging revealed that the modules I unlinked and tried collecting with `collectCompartmentGarbage` were never freed.
Further investigation showed that even if the module was not referred to from anywhere (as far as I see), it was still considered as referenced through a function it imports - the printf function.

There are two modules. One acting as the main program and another acting as a plugin. The plugin imports functions from the main program, for example, the printf function.
According to debugging, the plugin can't be collected because the printf function is referenced from somewhere. However, it is irrelevant if the function is referred to as it is an import and it continues to live even if the plugin module is unloaded.

**Solution:**
The code that marks the plugin module as not eligible for GC is the following:
https://github.com/WAVM/WAVM/blob/e289ba654fe51655ab080819fd85ed9c936aae6e/Lib/Runtime/ObjectGC.cpp#L189-L206

And once I did the following modification it works as I expect. The modification makes sure that the functions marking the module as a root are defined by the module instance (or is supposed to do that anyway).
```diff
- if(function && function->mutableData->numRootReferences)
+ if(function && function->mutableData->numRootReferences && function->instanceId == instance->id)
```

With the modification, the imported function no longer marks the plugin module as a root or referenced, so it can be collected by GC. After the change, I can load and unload the plugin as many times as I need to. I tested `dlopen` and `dlclose` a single module in a loop 100, 200, and 300 times and the max RAM consumption stayed the same between the three runs despite different amounts of modules.