### PR TITLE
Add missing <algorithm> includes

### DIFF
--- a/Lib/Runtime/Memory.cpp
+++ b/Lib/Runtime/Memory.cpp
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <memory>
 #include <vector>
+#include <algorithm>
 #include "RuntimePrivate.h"
 #include "WAVM/IR/IR.h"
 #include "WAVM/IR/Types.h"

--- a/Lib/Runtime/Table.cpp
+++ b/Lib/Runtime/Table.cpp
@@ -1,6 +1,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <vector>
+#include <algorithm>
 #include "RuntimePrivate.h"
 #include "WAVM/IR/Types.h"
 #include "WAVM/Inline/Assert.h"


### PR DESCRIPTION
I was getting these errors when trying to build libWAVM:
```
(...)\Lib\Runtime\Table.cpp(78,36): error C2039: 'min': is not a member of 'std'
(...)\Lib\Runtime\Table.cpp(78,39): error C3861: 'min': identifier not found
```
Also same for `Memory.cpp`. Adding `#include <algorithm>` fixed the issue.