### PR TITLE
Fix incorrect cxa_demangle usage causing program crash

### DIFF
--- a/Lib/Platform/POSIX/DiagnosticsPOSIX.cpp
+++ b/Lib/Platform/POSIX/DiagnosticsPOSIX.cpp
@@ -70,7 +70,7 @@ bool Platform::getInstructionSourceByAddress(Uptr ip, InstructionSource& outSour
 		}
 		else
 		{
-			char demangledBuffer[1024];
+			char* demangledBuffer = (char*)malloc(1024);
 			const char* demangledSymbolName = symbolInfo.dli_sname;
 			if(symbolInfo.dli_sname[0] == '_')
 			{

--- a/Lib/Platform/POSIX/DiagnosticsPOSIX.cpp
+++ b/Lib/Platform/POSIX/DiagnosticsPOSIX.cpp
@@ -70,7 +70,7 @@ bool Platform::getInstructionSourceByAddress(Uptr ip, InstructionSource& outSour
 		}
 		else
 		{
-			char* demangledBuffer = nullptr;
+			char* demangledBuffer = nullptr; // will be allocated by __cxa_demangle
 			const char* demangledSymbolName = symbolInfo.dli_sname;
 			if(symbolInfo.dli_sname[0] == '_')
 			{
@@ -83,6 +83,7 @@ bool Platform::getInstructionSourceByAddress(Uptr ip, InstructionSource& outSour
 				{ demangledSymbolName = demangledBuffer; }
 			}
 			outSource.function = demangledSymbolName;
+			free(demangledBuffer); // was copied to outSource.function
 			outSource.instructionOffset = ip - reinterpret_cast<Uptr>(symbolInfo.dli_saddr);
 		}
 		return true;

--- a/Lib/Platform/POSIX/DiagnosticsPOSIX.cpp
+++ b/Lib/Platform/POSIX/DiagnosticsPOSIX.cpp
@@ -70,7 +70,7 @@ bool Platform::getInstructionSourceByAddress(Uptr ip, InstructionSource& outSour
 		}
 		else
 		{
-			char* demangledBuffer = (char*)malloc(1024);
+			char* demangledBuffer = nullptr;
 			const char* demangledSymbolName = symbolInfo.dli_sname;
 			if(symbolInfo.dli_sname[0] == '_')
 			{

--- a/Lib/Platform/POSIX/DiagnosticsPOSIX.cpp
+++ b/Lib/Platform/POSIX/DiagnosticsPOSIX.cpp
@@ -77,9 +77,9 @@ bool Platform::getInstructionSourceByAddress(Uptr ip, InstructionSource& outSour
 				Uptr numDemangledChars = sizeof(demangledBuffer);
 				I32 demangleStatus = 0;
 				demangledBuffer = abi::__cxa_demangle(symbolInfo.dli_sname,
-									   demangledBuffer,
-									   (size_t*)&numDemangledChars,
-									   &demangleStatus);
+								                      demangledBuffer,
+									                  (size_t*)&numDemangledChars,
+									                  &demangleStatus);
 				if(demangledBuffer) { demangledSymbolName = demangledBuffer; }
 			}
 			outSource.function = demangledSymbolName;

--- a/Lib/Platform/POSIX/DiagnosticsPOSIX.cpp
+++ b/Lib/Platform/POSIX/DiagnosticsPOSIX.cpp
@@ -80,8 +80,7 @@ bool Platform::getInstructionSourceByAddress(Uptr ip, InstructionSource& outSour
 									   demangledBuffer,
 									   (size_t*)&numDemangledChars,
 									   &demangleStatus);
-				if(demangledBuffer)
-				{ demangledSymbolName = demangledBuffer; }
+				if(demangledBuffer) { demangledSymbolName = demangledBuffer; }
 			}
 			outSource.function = demangledSymbolName;
 			free(demangledBuffer); // was copied to outSource.function

--- a/Lib/Platform/POSIX/DiagnosticsPOSIX.cpp
+++ b/Lib/Platform/POSIX/DiagnosticsPOSIX.cpp
@@ -76,10 +76,11 @@ bool Platform::getInstructionSourceByAddress(Uptr ip, InstructionSource& outSour
 			{
 				Uptr numDemangledChars = sizeof(demangledBuffer);
 				I32 demangleStatus = 0;
-				if(abi::__cxa_demangle(symbolInfo.dli_sname,
+				demangledBuffer = abi::__cxa_demangle(symbolInfo.dli_sname,
 									   demangledBuffer,
 									   (size_t*)&numDemangledChars,
-									   &demangleStatus))
+									   &demangleStatus);
+				if(demangledBuffer)
 				{ demangledSymbolName = demangledBuffer; }
 			}
 			outSource.function = demangledSymbolName;


### PR DESCRIPTION
Recently my application, which uses WAVM, crashed at an innocuous describeException call with
```
kagome(98766,0x70000434f000) malloc: *** error for object 0x70000434cb10: pointer being realloc'd was not allocated
kagome(98766,0x70000434f000) malloc: *** set a breakpoint in malloc_error_break to debug
```

I went debugging this code, and found that currently describeException calls Platform::getInstructionSourceByAddress, which contains the following code:
```
			char demangledBuffer[1024];
			const char* demangledSymbolName = symbolInfo.dli_sname;
			if(symbolInfo.dli_sname[0] == '_')
			{
				Uptr numDemangledChars = sizeof(demangledBuffer);
				I32 demangleStatus = 0;
				if(abi::__cxa_demangle(symbolInfo.dli_sname,
									   demangledBuffer,
									   (size_t*)&numDemangledChars,
									   &demangleStatus))
				{ demangledSymbolName = demangledBuffer; }
			}
```
Mind the abi::__cxa_demangle call with demangledBuffer, allocated on stack, passed as the second argument.
Now let's have a look at __cxa_demangle docs:
https://gcc.gnu.org/onlinedocs/libstdc++/libstdc++-html-USERS-4.3/a01696.html
```output_buffer 	A region of memory, allocated with malloc, of *length bytes, into which the demangled name is stored. If output_buffer is not long enough, it is expanded using realloc. output_buffer may instead be NULL; in that case, the demangled name is placed in a region of memory allocated with malloc.```

It appers that this is the reason of the crash I encountered.