### PR TITLE
Fix build with Clang 13.

### DIFF
--- a/Lib/Platform/POSIX/ThreadPOSIX.cpp
+++ b/Lib/Platform/POSIX/ThreadPOSIX.cpp
@@ -173,6 +173,7 @@ WAVM_NO_ASAN static void touchStackPages(U8* minAddr, Uptr numBytesPerPage)
 		sum += *touchAddr;
 		if(touchAddr < minAddr + numBytesPerPage) { break; }
 	}
+	WAVM_SUPPRESS_UNUSED(sum);
 }
 
 bool Platform::initThreadAndGlobalSignalsOnce()


### PR DESCRIPTION
Fixes -Wunused-but-set-variable (enabled as part of -Wextra).

Signed-off-by: Piotr Sikora <piotrsikora@google.com>