### PR TITLE
Const-correct operator== and != for container iterators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,7 +448,7 @@ function(WAVM_SET_TARGET_COMPILE_OPTIONS TARGET_NAME)
 			   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/Include>
 	)
 
-	# Target C++11.
+	# Target C++14.
 	target_compile_features(${TARGET_NAME} PUBLIC cxx_std_14)
 	
 	# Set sanitizer options.

--- a/Include/WAVM/Inline/HashMap.h
+++ b/Include/WAVM/Inline/HashMap.h
@@ -23,8 +23,8 @@ namespace WAVM {
 
 		typedef HashMapPair<Key, Value> Pair;
 
-		bool operator!=(const HashMapIterator& other);
-		bool operator==(const HashMapIterator& other);
+		bool operator!=(const HashMapIterator& other) const;
+		bool operator==(const HashMapIterator& other) const;
 		operator bool() const;
 		void operator++();
 

--- a/Include/WAVM/Inline/HashSet.h
+++ b/Include/WAVM/Inline/HashSet.h
@@ -11,8 +11,8 @@ namespace WAVM {
 	{
 		template<typename, typename> friend struct HashSet;
 
-		bool operator!=(const HashSetIterator& other);
-		bool operator==(const HashSetIterator& other);
+		bool operator!=(const HashSetIterator& other) const;
+		bool operator==(const HashSetIterator& other) const;
 		operator bool() const;
 
 		void operator++();

--- a/Include/WAVM/Inline/Impl/HashMapImpl.h
+++ b/Include/WAVM/Inline/Impl/HashMapImpl.h
@@ -219,13 +219,13 @@ HashMapPair<Key, Value>::HashMapPair(Key&& inKey, ValueArgs&&... valueArgs)
 }
 
 template<typename Key, typename Value>
-bool HashMapIterator<Key, Value>::operator!=(const HashMapIterator& other)
+bool HashMapIterator<Key, Value>::operator!=(const HashMapIterator& other) const
 {
 	return bucket != other.bucket;
 }
 
 template<typename Key, typename Value>
-bool HashMapIterator<Key, Value>::operator==(const HashMapIterator& other)
+bool HashMapIterator<Key, Value>::operator==(const HashMapIterator& other) const
 {
 	return bucket == other.bucket;
 }

--- a/Include/WAVM/Inline/Impl/HashSetImpl.h
+++ b/Include/WAVM/Inline/Impl/HashSetImpl.h
@@ -1,12 +1,14 @@
 // IWYU pragma: private, include "WAVM/Inline/HashSet.h"
 // You should only include this file indirectly by including HashMap.h.
 
-template<typename Element> bool HashSetIterator<Element>::operator!=(const HashSetIterator& other)
+template<typename Element>
+bool HashSetIterator<Element>::operator!=(const HashSetIterator& other) const
 {
 	return bucket != other.bucket;
 }
 
-template<typename Element> bool HashSetIterator<Element>::operator==(const HashSetIterator& other)
+template<typename Element>
+bool HashSetIterator<Element>::operator==(const HashSetIterator& other) const
 {
 	return bucket == other.bucket;
 }

--- a/Include/WAVM/Inline/IndexMap.h
+++ b/Include/WAVM/Inline/IndexMap.h
@@ -107,8 +107,8 @@ namespace WAVM {
 		{
 			template<typename, typename> friend struct IndexMap;
 
-			bool operator!=(const Iterator& other) { return mapIt != other.mapIt; }
-			bool operator==(const Iterator& other) { return mapIt == other.mapIt; }
+			bool operator!=(const Iterator& other) const { return mapIt != other.mapIt; }
+			bool operator==(const Iterator& other) const { return mapIt == other.mapIt; }
 			operator bool() const { return bool(mapIt); }
 			void operator++() { ++mapIt; }
 


### PR DESCRIPTION
This fixes the following Werror warning from clang-13 when building WAVM embedded in a C++20 project:
```
WAVM/Lib/NFA/NFA.cpp:608:27: error: ISO C++20 considers use of overloaded operator '!=' (with operand types 'WAVM::HashMapIterator<short, WAVM::DenseStaticIntSet<unsigned char, 256>>' and 'WAVM::HashMapIterator<short, WAVM::DenseStaticIntSet<unsigned char, 256>>') to be ambiguous despite there being a unique best viable function with non-reversed arguments [-Werror,-Wambiguous-reversed-operator]
                for(auto transitionPair : transitions)
                                        ^
WAVM/Include/WAVM/Inline/HashMap.h:26:8: note: candidate function with non-reversed arguments
                bool operator!=(const HashMapIterator& other);
                     ^
WAVM/Include/WAVM/Inline/HashMap.h:27:8: note: ambiguous candidate function with reversed arguments
                bool operator==(const HashMapIterator& other);
```
