### PR TITLE
Fix nearest instruction to roundeven

### DIFF
--- a/Lib/LLVMJIT/EmitNumeric.cpp
+++ b/Lib/LLVMJIT/EmitNumeric.cpp
@@ -438,7 +438,7 @@ EMIT_FP_BINARY_OP(
 EMIT_FP_UNARY_OP(ceil, callLLVMIntrinsic({operand->getType()}, llvm::Intrinsic::ceil, {operand}))
 EMIT_FP_UNARY_OP(floor, callLLVMIntrinsic({operand->getType()}, llvm::Intrinsic::floor, {operand}))
 EMIT_FP_UNARY_OP(trunc, callLLVMIntrinsic({operand->getType()}, llvm::Intrinsic::trunc, {operand}))
-EMIT_FP_UNARY_OP(nearest, callLLVMIntrinsic({operand->getType()}, llvm::Intrinsic::rint, {operand}))
+EMIT_FP_UNARY_OP(nearest, callLLVMIntrinsic({operand->getType()}, llvm::Intrinsic::roundeven, {operand}))
 
 EMIT_SIMD_INT_BINARY_OP(add, irBuilder.CreateAdd(left, right))
 EMIT_SIMD_INT_BINARY_OP(sub, irBuilder.CreateSub(left, right))


### PR DESCRIPTION
The fnearest instruction: if two values are equally near, return the even one. https://webassembly.github.io/spec/core/exec/numerics.html#xref-exec-numerics-op-fnearest-mathrm-fnearest-n-z 
https://llvm.org/docs/LangRef.html#llvm-round-intrinsic