### PR TITLE
link with llvm-13 and llvm-14

### DIFF
--- a/Lib/LLVMJIT/EmitContext.h
+++ b/Lib/LLVMJIT/EmitContext.h
@@ -215,9 +215,7 @@ namespace WAVM { namespace LLVMJIT {
 				callArgs = llvm::ArrayRef<llvm::Value*>(callArgsAlloca, args.size() + 1);
 				callArgsAlloca[0] = irBuilder.CreateLoad(contextPointerVariable);
 				for(Uptr argIndex = 0; argIndex < args.size(); ++argIndex)
-				{
-					callArgsAlloca[1 + argIndex] = args[argIndex];
-				}
+				{ callArgsAlloca[1 + argIndex] = args[argIndex]; }
 			}
 
 			// Call or invoke the callee.

--- a/Lib/LLVMJIT/EmitContext.h
+++ b/Lib/LLVMJIT/EmitContext.h
@@ -109,12 +109,11 @@ namespace WAVM { namespace LLVMJIT {
 				MemoryInfo& memoryInfo = memoryInfos[memoryIndex];
 
 				llvm::Constant* memoryOffset = memoryOffsets[memoryIndex];
-				irBuilder.CreateStore(
-					loadFromUntypedPointer(
-						irBuilder.CreateInBoundsGEP(compartmentAddress, {memoryOffset}),
-						llvmContext.i8PtrType,
-						sizeof(U8*)),
-					memoryInfo.basePointerVariable);
+				irBuilder.CreateStore(loadFromUntypedPointer(irBuilder.CreateInBoundsGEP(
+																 compartmentAddress, memoryOffset),
+															 llvmContext.i8PtrType,
+															 sizeof(U8*)),
+									  memoryInfo.basePointerVariable);
 
 				llvm::Value* memoryNumReservedBytesOffset = llvm::ConstantExpr::getAdd(
 					memoryOffset,
@@ -122,7 +121,7 @@ namespace WAVM { namespace LLVMJIT {
 									memoryOffset->getType()));
 				irBuilder.CreateStore(
 					loadFromUntypedPointer(irBuilder.CreateInBoundsGEP(
-											   compartmentAddress, {memoryNumReservedBytesOffset}),
+											   compartmentAddress, memoryNumReservedBytesOffset),
 										   memoryOffset->getType()),
 					memoryInfo.endAddressVariable);
 			}
@@ -195,8 +194,7 @@ namespace WAVM { namespace LLVMJIT {
 						args[argIndex],
 						irBuilder.CreateInBoundsGEP(
 							argsArray,
-							{emitLiteral(llvmContext,
-										 Uptr(argIndex * sizeof(IR::UntaggedValue)))}));
+							emitLiteral(llvmContext, Uptr(argIndex * sizeof(IR::UntaggedValue)))));
 				}
 
 				resultsArray = irBuilder.CreateAlloca(
@@ -217,7 +215,9 @@ namespace WAVM { namespace LLVMJIT {
 				callArgs = llvm::ArrayRef<llvm::Value*>(callArgsAlloca, args.size() + 1);
 				callArgsAlloca[0] = irBuilder.CreateLoad(contextPointerVariable);
 				for(Uptr argIndex = 0; argIndex < args.size(); ++argIndex)
-				{ callArgsAlloca[1 + argIndex] = args[argIndex]; }
+				{
+					callArgsAlloca[1 + argIndex] = args[argIndex];
+				}
 			}
 
 			// Call or invoke the callee.
@@ -278,7 +278,7 @@ namespace WAVM { namespace LLVMJIT {
 
 						results.push_back(loadFromUntypedPointer(
 							irBuilder.CreateInBoundsGEP(newContextPointer,
-														{emitLiteral(llvmContext, resultOffset)}),
+														emitLiteral(llvmContext, resultOffset)),
 							asLLVMType(llvmContext, resultType),
 							resultNumBytes));
 
@@ -345,7 +345,7 @@ namespace WAVM { namespace LLVMJIT {
 					results.push_back(loadFromUntypedPointer(
 						irBuilder.CreateInBoundsGEP(
 							resultsArray,
-							{emitLiteral(llvmContext, resultIndex * sizeof(IR::UntaggedValue))}),
+							emitLiteral(llvmContext, resultIndex * sizeof(IR::UntaggedValue))),
 						asLLVMType(llvmContext, calleeType.results()[resultIndex])));
 				}
 
@@ -396,7 +396,7 @@ namespace WAVM { namespace LLVMJIT {
 										  irBuilder.CreatePointerCast(
 											  irBuilder.CreateInBoundsGEP(
 												  irBuilder.CreateLoad(contextPointerVariable),
-												  {emitLiteral(llvmContext, resultOffset)}),
+												  emitLiteral(llvmContext, resultOffset)),
 											  asLLVMType(llvmContext, resultType)->getPointerTo()));
 
 					resultOffset += resultNumBytes;

--- a/Lib/LLVMJIT/EmitCore.cpp
+++ b/Lib/LLVMJIT/EmitCore.cpp
@@ -68,9 +68,7 @@ void EmitFunctionContext::loop(ControlStructureImm imm)
 
 	// Pop the initial values of the loop's parameters from the stack.
 	for(Iptr elementIndex = Iptr(blockType.params().size()) - 1; elementIndex >= 0; --elementIndex)
-	{
-		parameterPHIs[elementIndex]->addIncoming(coerceToCanonicalType(pop()), loopEntryBlock);
-	}
+	{ parameterPHIs[elementIndex]->addIncoming(coerceToCanonicalType(pop()), loopEntryBlock); }
 
 	// Branch to the loop body and switch the IR builder to emit there.
 	irBuilder.CreateBr(loopBodyBlock);
@@ -183,9 +181,7 @@ void EmitFunctionContext::end(NoImm)
 		for(Uptr elementIndex = 0; elementIndex < currentContext.endPHIs.size(); ++elementIndex)
 		{
 			if(currentContext.endPHIs[elementIndex]->getNumIncomingValues())
-			{
-				push(currentContext.endPHIs[elementIndex]);
-			}
+			{ push(currentContext.endPHIs[elementIndex]); }
 			else
 			{
 				// If there weren't any incoming values for the end PHI, remove it and push
@@ -342,9 +338,7 @@ void EmitFunctionContext::call(FunctionImm imm)
 
 	// Coerce the arguments to their canonical type.
 	for(Uptr argIndex = 0; argIndex < numArguments; ++argIndex)
-	{
-		llvmArgs[argIndex] = coerceToCanonicalType(llvmArgs[argIndex]);
-	}
+	{ llvmArgs[argIndex] = coerceToCanonicalType(llvmArgs[argIndex]); }
 
 	// Call the function.
 	ValueVector results = emitCallOrInvoke(callee,
@@ -371,9 +365,7 @@ void EmitFunctionContext::call_indirect(CallIndirectImm imm)
 
 	// Coerce the arguments to their canonical type.
 	for(Uptr argIndex = 0; argIndex < numArguments; ++argIndex)
-	{
-		llvmArgs[argIndex] = coerceToCanonicalType(llvmArgs[argIndex]);
-	}
+	{ llvmArgs[argIndex] = coerceToCanonicalType(llvmArgs[argIndex]); }
 
 	// Zero extend the function index to the pointer size.
 	elementIndex = zext(elementIndex, moduleContext.iptrType);

--- a/Lib/LLVMJIT/EmitExceptions.cpp
+++ b/Lib/LLVMJIT/EmitExceptions.cpp
@@ -164,7 +164,7 @@ void EmitFunctionContext::try_(ControlStructureImm imm)
 		auto exceptionTypeId = loadFromUntypedPointer(
 			irBuilder.CreateInBoundsGEP(
 				exceptionPointer,
-				{emitLiteralIptr(offsetof(Exception, typeId), moduleContext.iptrType)}),
+				emitLiteralIptr(offsetof(Exception, typeId), moduleContext.iptrType)),
 			moduleContext.iptrType);
 
 		tryStack.push_back(TryContext{catchSwitchBlock});
@@ -192,7 +192,7 @@ void EmitFunctionContext::try_(ControlStructureImm imm)
 		auto exceptionTypeId = loadFromUntypedPointer(
 			irBuilder.CreateInBoundsGEP(
 				exceptionPointer,
-				{emitLiteralIptr(offsetof(Exception, typeId), moduleContext.iptrType)}),
+				emitLiteralIptr(offsetof(Exception, typeId), moduleContext.iptrType)),
 			moduleContext.iptrType);
 
 		tryStack.push_back(TryContext{landingPadBlock});
@@ -264,7 +264,7 @@ void EmitFunctionContext::catch_(ExceptionTypeImm imm)
 			  + (catchType.params.size() - argumentIndex - 1) * sizeof(Exception::arguments[0]);
 		auto argument = loadFromUntypedPointer(
 			irBuilder.CreateInBoundsGEP(catchContext.exceptionPointer,
-										{emitLiteral(llvmContext, argOffset)}),
+										emitLiteral(llvmContext, argOffset)),
 			asLLVMType(llvmContext, parameters),
 			sizeof(Exception::arguments[0]));
 		push(argument);
@@ -299,7 +299,7 @@ void EmitFunctionContext::catch_all(NoImm)
 		loadFromUntypedPointer(
 			irBuilder.CreateInBoundsGEP(
 				catchContext.exceptionPointer,
-				{emitLiteralIptr(offsetof(Exception, isUserException), moduleContext.iptrType)}),
+				emitLiteralIptr(offsetof(Exception, isUserException), moduleContext.iptrType)),
 			llvmContext.i8Type),
 		llvm::ConstantInt::get(llvmContext.i8Type, llvm::APInt(8, 0, false)));
 
@@ -333,7 +333,7 @@ void EmitFunctionContext::throw_(ExceptionTypeImm imm)
 			irBuilder.CreatePointerCast(
 				irBuilder.CreateInBoundsGEP(
 					argBaseAddress,
-					{emitLiteral(llvmContext, (numArgs - argIndex - 1) * sizeof(UntaggedValue))}),
+					emitLiteral(llvmContext, (numArgs - argIndex - 1) * sizeof(UntaggedValue))),
 				elementValue->getType()->getPointerTo()),
 			sizeof(UntaggedValue));
 	}

--- a/Lib/LLVMJIT/EmitMem.cpp
+++ b/Lib/LLVMJIT/EmitMem.cpp
@@ -43,10 +43,10 @@ static llvm::Value* getMemoryNumPages(EmitFunctionContext& functionContext, Uptr
 	llvm::LoadInst* memoryNumPagesLoad = functionContext.loadFromUntypedPointer(
 		functionContext.irBuilder.CreateInBoundsGEP(
 			functionContext.getCompartmentAddress(),
-			{llvm::ConstantExpr::getAdd(
+			llvm::ConstantExpr::getAdd(
 				memoryOffset,
 				emitLiteralIptr(offsetof(Runtime::MemoryRuntimeData, numPages),
-								functionContext.moduleContext.iptrType))}),
+								functionContext.moduleContext.iptrType))),
 		functionContext.moduleContext.iptrType,
 		functionContext.moduleContext.iptrAlignment);
 	memoryNumPagesLoad->setAtomic(llvm::AtomicOrdering::Acquire);
@@ -513,7 +513,7 @@ static void emitLoadInterleaved(EmitFunctionContext& functionContext,
 		{
 			auto load
 				= functionContext.irBuilder.CreateLoad(functionContext.irBuilder.CreateInBoundsGEP(
-					pointer, {emitLiteral(functionContext.llvmContext, U32(vectorIndex))}));
+					pointer, emitLiteral(functionContext.llvmContext, U32(vectorIndex))));
 			/* Don't trust the alignment hint provided by the WebAssembly code, since the load
 			 * can't trap if it's wrong. */
 			load->setAlignment(LLVM_ALIGNMENT(1));
@@ -596,7 +596,7 @@ static void emitStoreInterleaved(EmitFunctionContext& functionContext,
 			auto store = functionContext.irBuilder.CreateStore(
 				interleavedVector,
 				functionContext.irBuilder.CreateInBoundsGEP(
-					pointer, {emitLiteral(functionContext.llvmContext, U32(vectorIndex))}));
+					pointer, emitLiteral(functionContext.llvmContext, U32(vectorIndex))));
 			store->setVolatile(true);
 			store->setAlignment(LLVM_ALIGNMENT(1));
 		}

--- a/Lib/LLVMJIT/EmitVar.cpp
+++ b/Lib/LLVMJIT/EmitVar.cpp
@@ -72,7 +72,7 @@ void EmitFunctionContext::global_get(GetOrSetVariableImm<true> imm)
 		llvm::Value* globalDataOffset = irBuilder.CreatePtrToInt(
 			moduleContext.globals[imm.variableIndex], moduleContext.iptrType);
 		llvm::Value* globalPointer = irBuilder.CreateInBoundsGEP(
-			irBuilder.CreateLoad(contextPointerVariable), {globalDataOffset});
+			irBuilder.CreateLoad(contextPointerVariable), globalDataOffset);
 		value = loadFromUntypedPointer(globalPointer,
 									   asLLVMType(llvmContext, globalType.valueType),
 									   getTypeByteWidth(globalType.valueType));
@@ -148,6 +148,6 @@ void EmitFunctionContext::global_set(GetOrSetVariableImm<true> imm)
 	llvm::Value* globalDataOffset = irBuilder.CreatePtrToInt(
 		moduleContext.globals[imm.variableIndex], moduleContext.iptrType);
 	llvm::Value* globalPointer = irBuilder.CreateInBoundsGEP(
-		irBuilder.CreateLoad(contextPointerVariable), {globalDataOffset});
+		irBuilder.CreateLoad(contextPointerVariable), globalDataOffset);
 	storeToUntypedPointer(value, globalPointer);
 }

--- a/Lib/LLVMJIT/LLVMJITPrivate.h
+++ b/Lib/LLVMJIT/LLVMJITPrivate.h
@@ -163,9 +163,7 @@ namespace WAVM { namespace LLVMJIT {
 	{
 		llvm::Type** llvmTypes = (llvm::Type**)alloca(sizeof(llvm::Type*) * typeTuple.size());
 		for(Uptr typeIndex = 0; typeIndex < typeTuple.size(); ++typeIndex)
-		{
-			llvmTypes[typeIndex] = asLLVMType(llvmContext, typeTuple[typeIndex]);
-		}
+		{ llvmTypes[typeIndex] = asLLVMType(llvmContext, typeTuple[typeIndex]); }
 		return llvm::StructType::get(llvmContext,
 									 llvm::ArrayRef<llvm::Type*>(llvmTypes, typeTuple.size()));
 	}
@@ -222,9 +220,7 @@ namespace WAVM { namespace LLVMJIT {
 			numParameters = numImplicitParameters + functionType.params().size();
 			llvmArgTypes = (llvm::Type**)alloca(sizeof(llvm::Type*) * numParameters);
 			if(callingConvention != IR::CallingConvention::c)
-			{
-				llvmArgTypes[0] = llvmContext.i8PtrType;
-			}
+			{ llvmArgTypes[0] = llvmContext.i8PtrType; }
 
 			for(Uptr argIndex = 0; argIndex < functionType.params().size(); ++argIndex)
 			{
@@ -338,8 +334,7 @@ namespace WAVM { namespace LLVMJIT {
 				function->getContext(),
 				llvm::AttributeList::FunctionIndex,
 				"no-frame-pointer-elim",
-				"true"
-			);
+				"true");
 
 			// Set the probe-stack attribute: this will cause functions that allocate more than a
 			// page of stack space to call the wavm_probe_stack function defined in POSIX.S
@@ -351,8 +346,7 @@ namespace WAVM { namespace LLVMJIT {
 				function->getContext(),
 				llvm::AttributeList::FunctionIndex,
 				"probe-stack",
-				"wavm_probe_stack"
-			);
+				"wavm_probe_stack");
 
 			function->setAttributes(attrs);
 		}

--- a/Lib/LLVMJIT/LLVMJITPrivate.h
+++ b/Lib/LLVMJIT/LLVMJITPrivate.h
@@ -330,17 +330,29 @@ namespace WAVM { namespace LLVMJIT {
 
 			// LLVM 9+ has a more general purpose frame-pointer=(all|non-leaf|none) attribute that
 			// WAVM should use once we can depend on it.
-			attrs = attrs.addAttribute(function->getContext(),
-									   llvm::AttributeList::FunctionIndex,
-									   "no-frame-pointer-elim",
-									   "true");
+#if LLVM_VERSION_MAJOR < 14
+			attrs = attrs.addAttribute(
+#else
+			attrs = attrs.addAttributeAtIndex(
+#endif
+				function->getContext(),
+				llvm::AttributeList::FunctionIndex,
+				"no-frame-pointer-elim",
+				"true"
+			);
 
 			// Set the probe-stack attribute: this will cause functions that allocate more than a
 			// page of stack space to call the wavm_probe_stack function defined in POSIX.S
-			attrs = attrs.addAttribute(function->getContext(),
-									   llvm::AttributeList::FunctionIndex,
-									   "probe-stack",
-									   "wavm_probe_stack");
+#if LLVM_VERSION_MAJOR < 14
+			attrs = attrs.addAttribute(
+#else
+			attrs = attrs.addAttributeAtIndex(
+#endif
+				function->getContext(),
+				llvm::AttributeList::FunctionIndex,
+				"probe-stack",
+				"wavm_probe_stack"
+			);
 
 			function->setAttributes(attrs);
 		}

--- a/Lib/LLVMJIT/LLVMJITPrivate.h
+++ b/Lib/LLVMJIT/LLVMJITPrivate.h
@@ -163,7 +163,9 @@ namespace WAVM { namespace LLVMJIT {
 	{
 		llvm::Type** llvmTypes = (llvm::Type**)alloca(sizeof(llvm::Type*) * typeTuple.size());
 		for(Uptr typeIndex = 0; typeIndex < typeTuple.size(); ++typeIndex)
-		{ llvmTypes[typeIndex] = asLLVMType(llvmContext, typeTuple[typeIndex]); }
+		{
+			llvmTypes[typeIndex] = asLLVMType(llvmContext, typeTuple[typeIndex]);
+		}
 		return llvm::StructType::get(llvmContext,
 									 llvm::ArrayRef<llvm::Type*>(llvmTypes, typeTuple.size()));
 	}
@@ -220,7 +222,9 @@ namespace WAVM { namespace LLVMJIT {
 			numParameters = numImplicitParameters + functionType.params().size();
 			llvmArgTypes = (llvm::Type**)alloca(sizeof(llvm::Type*) * numParameters);
 			if(callingConvention != IR::CallingConvention::c)
-			{ llvmArgTypes[0] = llvmContext.i8PtrType; }
+			{
+				llvmArgTypes[0] = llvmContext.i8PtrType;
+			}
 
 			for(Uptr argIndex = 0; argIndex < functionType.params().size(); ++argIndex)
 			{
@@ -433,3 +437,15 @@ namespace WAVM { namespace LLVMJIT {
 								 const U8* xdataCopy,
 								 Uptr sehTrampolineAddress);
 }}
+
+// LLVM 13 requires some extra arguments in Create functions
+#if LLVM_VERSION_MAJOR >= 13
+#define CreateLoad(Ptr) CreateLoad(Ptr->getType()->getScalarType()->getPointerElementType(), Ptr)
+#define CreateInBoundsGEP(Ptr, IdxList)                                                            \
+	CreateInBoundsGEP(Ptr->getType()->getScalarType()->getPointerElementType(), Ptr, IdxList)
+
+#define CreateAtomicCmpXchg(Op, Cmp, New, SuccessOrdering, FailureOrdering)                        \
+	CreateAtomicCmpXchg(Op, Cmp, New, llvm::MaybeAlign(), SuccessOrdering, FailureOrdering)
+#define CreateAtomicRMW(Op, Ptr, Val, Ordering)                                                    \
+	CreateAtomicRMW(Op, Ptr, Val, llvm::MaybeAlign(), Ordering)
+#endif

--- a/Lib/LLVMJIT/Thunk.cpp
+++ b/Lib/LLVMJIT/Thunk.cpp
@@ -85,9 +85,7 @@ InvokeThunkPointer LLVMJIT::getInvokeThunk(FunctionType functionType)
 	Runtime::Function*& invokeThunkFunction
 		= invokeThunkCache.typeToFunctionMap.getOrAdd(functionType, nullptr);
 	if(invokeThunkFunction)
-	{
-		return reinterpret_cast<InvokeThunkPointer>(const_cast<U8*>(invokeThunkFunction->code));
-	}
+	{ return reinterpret_cast<InvokeThunkPointer>(const_cast<U8*>(invokeThunkFunction->code)); }
 
 	// Create a FunctionMutableData object for the thunk.
 	FunctionMutableData* functionMutableData


### PR DESCRIPTION
This PR adds compatibility with llvm 13 and 14. At the same time, it should not break compatibility with older llvm versions.
Version 14 is particularly nice to have since it's default in Ubuntu 22.04 as well as Debian testing / bookworm.

I'm happy for suggestions, e.g., the macro hack for `Create*()` functions is perhaps a bit nasty, but very compact.
A third commit comments out some lines in the `CMakeFile` that cause cmake (version 3.25.1) to error out - this particular change might need some fine-tuning for older cmake versions.